### PR TITLE
fix set/frozenset as values argument for Connection.select method

### DIFF
--- a/src/tarantool/connection.py
+++ b/src/tarantool/connection.py
@@ -367,12 +367,13 @@ class Connection(object):
             values = [(values, )]
         elif isinstance(values, (list, tuple, set, frozenset)):
             assert len(values) > 0
-            if isinstance(values[0], (int, long, basestring)): # list of scalars
+            any_value = next(iter(values))
+            if isinstance(any_value, (int, long, basestring)): # list of scalars
                 # This request is looking for several records using single-valued index
                 # Ex: select(space_no, index_no, [1, 2, 3])
                 # Transform a list of scalar values to a list of tuples
                 values = [(v, ) for v in values]
-            elif isinstance(values[0], (list, tuple)): # list of tuples
+            elif isinstance(any_value, (list, tuple)): # list of tuples
                 # This request is looking for serveral records using composite index
                 pass
             else:


### PR DESCRIPTION
Fix value type detection for sequence objects.
Tested on python2 and python3.
