### PR TITLE
Add generate_sync method to tarantool.Connection class

### DIFF
--- a/tarantool/__init__.py
+++ b/tarantool/__init__.py
@@ -24,7 +24,7 @@ from tarantool.schema import (
 )
 
 
-def connect(host="localhost", port=33013):
+def connect(host="localhost", port=33013, user=None, password=None):
     '''\
     Create a connection to the Tarantool server.
 
@@ -37,8 +37,8 @@ def connect(host="localhost", port=33013):
     '''
 
     return Connection(host, port,
-                      user=None,
-                      password=None,
+                      user=user,
+                      password=password,
                       socket_timeout=SOCKET_TIMEOUT,
                       reconnect_max_attempts=RECONNECT_MAX_ATTEMPTS,
                       reconnect_delay=RECONNECT_DELAY,

--- a/tarantool/__init__.py
+++ b/tarantool/__init__.py
@@ -37,6 +37,8 @@ def connect(host="localhost", port=33013):
     '''
 
     return Connection(host, port,
+                      user=None,
+                      password=None,
                       socket_timeout=SOCKET_TIMEOUT,
                       reconnect_max_attempts=RECONNECT_MAX_ATTEMPTS,
                       reconnect_delay=RECONNECT_DELAY,

--- a/tarantool/connection.py
+++ b/tarantool/connection.py
@@ -518,3 +518,9 @@ class Connection(object):
         :rtype: `Space` instance
         '''
         return Space(self, space_name)
+
+    def generate_sync(self):
+        """\
+        Need override for async io connection
+        """
+        return 0

--- a/tarantool/request.py
+++ b/tarantool/request.py
@@ -53,15 +53,27 @@ class Request(object):
     def __init__(self, conn):
         self._bytes = None
         self.conn = conn
+        self._sync = None
 
     def __bytes__(self):
         return self._bytes
     __str__ = __bytes__
 
-    @classmethod
-    def header(cls, length):
-        header = msgpack.dumps({ IPROTO_CODE : cls.request_type,
-                                IPROTO_SYNC : 0})
+    @property
+    def sync(self):
+        '''\
+        :type: int
+
+        Required field in the server request.
+        Contains request header IPROTO_SYNC.
+        '''
+        return self._sync
+
+    def header(self, length):
+        self._sync = self.conn.generate_sync()
+        header = msgpack.dumps({IPROTO_CODE: self.request_type,
+                                IPROTO_SYNC: self._sync})
+
         return msgpack.dumps(length + len(header)) + header
 
 class RequestInsert(Request):

--- a/tarantool/response.py
+++ b/tarantool/response.py
@@ -120,6 +120,16 @@ class Response(list):
         return self._code
 
     @property
+    def sync(self):
+        '''\
+        :type: int
+
+        Required field in the server response.
+        Contains response header IPROTO_SYNC.
+        '''
+        return self._sync
+
+    @property
     def return_code(self):
         '''\
         :type: int


### PR DESCRIPTION
These improvements will not affect the implementation of the current driver code.

However, this would greatly simplify the implementation of gtarantool driver https://github.com/shveenkov/gtarantool.

GRequest, GResponse classes will be removed, also, do not need to copy-paste methods select / insert / delete in TarantoolCoroConnection.