### PR TITLE
add encoding feature for py3 tarantool.connect

### DIFF
--- a/tarantool/__init__.py
+++ b/tarantool/__init__.py
@@ -7,7 +7,8 @@ from tarantool.connection import Connection
 from tarantool.const import (
     SOCKET_TIMEOUT,
     RECONNECT_MAX_ATTEMPTS,
-    RECONNECT_DELAY
+    RECONNECT_DELAY,
+    ENCODING_DEFAULT
 )
 
 from tarantool.error import (
@@ -24,7 +25,7 @@ from tarantool.schema import (
 )
 
 
-def connect(host="localhost", port=33013, user=None, password=None):
+def connect(host="localhost", port=33013, user=None, password=None, encoding=ENCODING_DEFAULT):
     '''\
     Create a connection to the Tarantool server.
 
@@ -42,7 +43,9 @@ def connect(host="localhost", port=33013, user=None, password=None):
                       socket_timeout=SOCKET_TIMEOUT,
                       reconnect_max_attempts=RECONNECT_MAX_ATTEMPTS,
                       reconnect_delay=RECONNECT_DELAY,
-                      connect_now=True)
+                      connect_now=True,
+                      encoding=encoding)
+
 
 __all__ = ['connect', 'Connection', 'Schema', 'Error', 'DatabaseError',
            'NetworkError', 'NetworkWarning', 'RetryWarning', 'SchemaError']

--- a/tarantool/connection.py
+++ b/tarantool/connection.py
@@ -43,13 +43,16 @@ from tarantool.const import (
     RETRY_MAX_ATTEMPTS,
     REQUEST_TYPE_OK,
     REQUEST_TYPE_ERROR,
-    IPROTO_GREETING_SIZE)
+    IPROTO_GREETING_SIZE,
+    ENCODING_DEFAULT)
+
 from tarantool.error import (
     NetworkError,
     DatabaseError,
     warn,
     RetryWarning,
     NetworkWarning)
+
 from tarantool.schema import Schema
 from tarantool.utils import check_key
 
@@ -75,7 +78,8 @@ class Connection(object):
                  socket_timeout=SOCKET_TIMEOUT,
                  reconnect_max_attempts=RECONNECT_MAX_ATTEMPTS,
                  reconnect_delay=RECONNECT_DELAY,
-                 connect_now=True):
+                 connect_now=True,
+                 encoding=ENCODING_DEFAULT):
         '''
         Initialize a connection to the server.
 
@@ -101,6 +105,7 @@ class Connection(object):
         self._socket = None
         self.connected = False
         self.error = True
+        self.encoding = encoding
         if connect_now:
             self.connect()
 

--- a/tarantool/const.py
+++ b/tarantool/const.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C0301,W0105,W0401,W0614
 
+import six
+
 IPROTO_CODE = 0x00
 IPROTO_SYNC = 0x01
 IPROTO_SPACE_ID = 0x10
@@ -69,3 +71,8 @@ RECONNECT_DELAY = 0.1
 # Number of reattempts in case of server
 # return completion_status == 1 (try again)
 RETRY_MAX_ATTEMPTS = 10
+
+if six.PY2:
+    ENCODING_DEFAULT = None
+else:
+    ENCODING_DEFAULT = "utf-8"

--- a/tarantool/response.py
+++ b/tarantool/response.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C0301,W0105,W0401,W0614
 
-import six
 import sys
 import msgpack
 import yaml
@@ -42,10 +41,10 @@ class Response(list):
         # created in the __new__(). But let it be.
         super(Response, self).__init__()
 
-        if six.PY2:
-            unpacker = msgpack.Unpacker(use_list=True)
+        if conn.encoding is not None:
+            unpacker = msgpack.Unpacker(use_list=True, encoding=conn.encoding)
         else:
-            unpacker = msgpack.Unpacker(use_list=True, encoding="utf-8")
+            unpacker = msgpack.Unpacker(use_list=True)
 
         unpacker.feed(response)
         header = unpacker.unpack()

--- a/tarantool/schema.py
+++ b/tarantool/schema.py
@@ -15,6 +15,8 @@ class SchemaIndex(object):
     def __init__(self, array, space):
         self.iid = array[1]
         self.name = array[2]
+        if isinstance(self.name, bytes):
+            self.name = self.name.decode()
         self.index = array[3]
         self.unique = array[4]
         self.parts = []
@@ -36,6 +38,8 @@ class SchemaSpace(object):
         self.sid = array[0]
         self.arity = array[1]
         self.name = array[2]
+        if isinstance(self.name, bytes):
+            self.name = self.name.decode()
         self.indexes = {}
         self.schema = schema
         self.schema[self.sid] = self


### PR DESCRIPTION
if you want to insert binary data in tarantool, msgpack.unpack raise Exception in python3

```python
>>> import tarantool
>>> import msgpack
>>> tnt=tarantool.connect("127.0.0.1", 3301)
>>> tnt.insert("tester", (1, msgpack.packb([1,2,3,"foo"])))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/shveenkov/env_34/lib/python3.4/site-packages/tarantool/connection.py", line 389, in insert
    return self._send_request(request)
  File "/home/shveenkov/env_34/lib/python3.4/site-packages/tarantool/connection.py", line 275, in _send_request
    request)
  File "/home/shveenkov/env_34/lib/python3.4/site-packages/tarantool/connection.py", line 199, in _send_request_wo_reconnect
    response = Response(self, self._read_response())
  File "/home/shveenkov/env_34/lib/python3.4/site-packages/tarantool/response.py", line 57, in __init__
    self._body = unpacker.unpack()
  File "msgpack/_unpacker.pyx", line 427, in msgpack._unpacker.Unpacker.unpack (msgpack/_unpacker.cpp:427)
  File "msgpack/_unpacker.pyx", line 390, in msgpack._unpacker.Unpacker._unpack (msgpack/_unpacker.cpp:390)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x94 in position 0: invalid start byte
>>> 
>>> 
>>> tnt=tarantool.connect("127.0.0.1", 3301, encoding=None)
>>> tnt.insert("tester", (1, msgpack.packb([1,2,3,"foo"])))
```
