### PR TITLE
fix work with socket on windows

### DIFF
--- a/tarantool/connection.py
+++ b/tarantool/connection.py
@@ -11,6 +11,7 @@ import ctypes
 import ctypes.util
 import socket
 import msgpack
+import os
 
 try:
     from ctypes import c_ssize_t
@@ -89,7 +90,10 @@ class Connection(object):
         creates network connection.
                              if False than you have to call connect() manualy.
         '''
-        libc = ctypes.CDLL(ctypes.util.find_library('c'), use_errno=True)
+        if os.name == 'nt':
+            libc = ctypes.CDLL(ctypes.util.find_library('Ws2_32'), use_errno=True)
+        else:
+            libc = ctypes.CDLL(ctypes.util.find_library('c'), use_errno=True)
         recv = self._sys_recv = libc.recv
         recv.argtypes = [
             ctypes.c_int, ctypes.c_void_p, c_ssize_t, ctypes.c_int]


### PR DESCRIPTION
fix connection error on windows platform:
```
>>> import tarantool
>>> tarantool.connect('48.12.22.123',3311)

Traceback (most recent call last):
  File "<pyshell#2>", line 1, in <module>
    tarantool.connect('48.12.22.123',3311)
  File "C:\Python27\lib\site-packages\tarantool\__init__.py", line 47, in connect
    encoding=encoding)
  File "C:\Python27\lib\site-packages\tarantool\connection.py", line 93, in __init__
    recv = self._sys_recv = libc.recv
  File "C:\Python27\lib\ctypes\__init__.py", line 378, in __getattr__
    func = self.__getitem__(name)
  File "C:\Python27\lib\ctypes\__init__.py", line 383, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
AttributeError: function 'recv' not found
```