### PR TITLE
fix UnicodeDecodeError when printing tuples with binary data

### DIFF
--- a/tarantool/response.py
+++ b/tarantool/response.py
@@ -229,7 +229,7 @@ class Response(collections.Sequence):
             }, sort_keys = True, indent = 4)
         output = []
         for tpl in self._data:
-            output.extend(("- ", json.dumps(tpl), "\n"))
+            output.extend(("- ", repr(tpl), "\n"))
         if len(output) > 0:
             output.pop()
         return ''.join(output)

--- a/tests/suites/test_dml.py
+++ b/tests/suites/test_dml.py
@@ -60,7 +60,7 @@ class TestSuite_Request(unittest.TestCase):
                     [i, i%5, 'tuple_'+str(i)]
             )
     def test_00_03_answer_repr(self):
-        repr_str = """- [1, 1, "tuple_1"]"""
+        repr_str = """- [1, 1, 'tuple_1']"""
         self.assertEqual(repr(self.con.select('space_1', 1)), repr_str)
 
     def test_02_select(self):


### PR DESCRIPTION
The following script fails when trying to print tuple with raw byte field that is not valid utf8:

    import tarantool
    conn = tarantool.connect('localhost', 31539, encoding=None)
    conn.replace('test_space', ('foo', b'\xff'))
    print(conn.select('test_space', 'foo'))

traceback:
```
  File "/Users/zimnukhov/tmp/tarantool-python/tarantool/response.py", line 232, in __str__
    output.extend(("- ", json.dumps(tpl), "\n"))
  File "/usr/lib/python2.7/json/__init__.py", line 243, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xff in position 0: invalid start byte
```

I suggest using repr instead of json to serialize tuples. The above script will print:
```
- ['foo', '\xff']
```