### PR TITLE
Eliminate deprecation warnings

### DIFF
--- a/tarantool/response.py
+++ b/tarantool/response.py
@@ -45,7 +45,12 @@ class Response(collections.Sequence):
         # created in the __new__().
         # super(Response, self).__init__()
 
-        if conn.encoding is not None:
+        if msgpack.version >= (0, 5, 2) and conn.encoding == 'utf-8':
+            # Get rid of the following warning.
+            # > PendingDeprecationWarning: encoding is deprecated,
+            # > Use raw=False instead.
+            unpacker = msgpack.Unpacker(use_list=True, raw=False)
+        elif conn.encoding is not None:
             unpacker = msgpack.Unpacker(use_list=True, encoding=conn.encoding)
         else:
             unpacker = msgpack.Unpacker(use_list=True)

--- a/tarantool/utils.py
+++ b/tarantool/utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import sys
-import base64
 import uuid
 
 # Compatibility layer for Python2/Python3
@@ -12,6 +11,7 @@ if sys.version_info.major == 2:
         binary_types = (str, )
     else:
         binary_types = (bytes, )
+    from base64 import decodestring as base64_decode
 
     def strxor(rhs, lhs):
         return "".join(chr(ord(x) ^ ord(y)) for x, y in zip(rhs, lhs))
@@ -21,6 +21,7 @@ elif sys.version_info.major == 3:
     string_types  = (str, )
     integer_types = (int, )
     ENCODING_DEFAULT = "utf-8"
+    from base64 import decodebytes as base64_decode
 
     def strxor(rhs, lhs):
         return bytes([x ^ y for x, y in zip(rhs, lhs)])
@@ -84,8 +85,8 @@ def greeting_decode(greeting_buf):
             # Tarantool < 1.6.7 doesn't add "(Binary)" to greeting
             result.protocol = "Binary"
         elif len(tail.strip()) != 0:
-            raise Exception("x")  # Unsuported greeting
-        result.salt = base64.decodestring(greeting_buf[64:])[:20]
+            raise Exception("x")  # Unsupported greeting
+        result.salt = base64_decode(greeting_buf[64:])[:20]
         return result
     except Exception as e:
         print('exx', e)


### PR DESCRIPTION
See [1] for more information about the msgpack warning.

[1]: https://github.com/msgpack/msgpack-python/blob/381c2eff5f8ee0b8669fd6daf1fd1ecaffe7c931/README.rst#deprecating-encoding-option

Fixes #114.