### PR TITLE
test: fail CI if a test fails

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,17 @@
-#!/bin/bash
+#!/bin/sh
 
-curl http://tarantool.org/dist/public.key | sudo apt-key add -
-echo "deb http://tarantool.org/dist/master/ubuntu/ `lsb_release -c -s` main" | sudo tee -a /etc/apt/sources.list.d/tarantool.list
+set -exu # Strict shell (w/o -o pipefail)
+
+# Install tarantool.
+curl http://download.tarantool.org/tarantool/2x/gpgkey | sudo apt-key add -
+release=`lsb_release -c -s`
+echo "deb http://download.tarantool.org/tarantool/2x/ubuntu/ ${release} main" | sudo tee /etc/apt/sources.list.d/tarantool_2x.list
 sudo apt-get update > /dev/null
 sudo apt-get -q -y install tarantool
+
+# Install testing dependencies.
 pip install -r requirements.txt
+pip install pyyaml
+
+# Run tests.
 python setup.py test

--- a/unit/setup_command.py
+++ b/unit/setup_command.py
@@ -4,6 +4,7 @@ import os
 import sys
 import unittest
 import setuptools
+from distutils.errors import DistutilsError
 
 from glob import glob
 
@@ -23,5 +24,7 @@ class test(setuptools.Command):
         '''
 
         tests = unittest.defaultTestLoader.discover('unit')
-        test_runner = unittest.TextTestRunner(verbosity = 2)
-        test_runner.run(tests)
+        test_runner = unittest.TextTestRunner(verbosity=2)
+        result = test_runner.run(tests)
+        if not result.wasSuccessful():
+            raise DistutilsError('There are failed tests')

--- a/unit/suites/test_protocol.py
+++ b/unit/suites/test_protocol.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env ipython
+# -*- coding: utf-8 -*-
 
 import unittest
 from tarantool.utils import greeting_decode, version_id

--- a/unit/suites/test_schema.py
+++ b/unit/suites/test_schema.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env ipython
+# -*- coding: utf-8 -*-
 
 import unittest
 import tarantool


### PR DESCRIPTION
* Fixed exit code of `python setup.py test` (was always zero).
* Fixed exit code of test.sh (was always zero).
* Fixed tarantool repo URI.
* Added pyyaml as testing dependency.
* Dropped shebangs and executable bits for test files (for unification
  purposes).

Fixes #121.