### PR TITLE
test: print test suite headers to stderr

### DIFF
--- a/unit/suites/test_dml.py
+++ b/unit/suites/test_dml.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+
+import sys
 import unittest
 import tarantool
 
@@ -8,8 +11,8 @@ from .lib.tarantool_server import TarantoolServer
 class TestSuite_Request(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        print(' DML '.center(70, '='))
-        print('-' * 70)
+        print(' DML '.center(70, '='), file=sys.stderr)
+        print('-' * 70, file=sys.stderr)
         self.srv = TarantoolServer()
         self.srv.script = 'unit/suites/box.lua'
         self.srv.start()

--- a/unit/suites/test_protocol.py
+++ b/unit/suites/test_protocol.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env ipython
 
+from __future__ import print_function
+
+import sys
 import unittest
 from tarantool.utils import greeting_decode, version_id
 import uuid
@@ -7,8 +10,8 @@ import uuid
 class TestSuite_Protocol(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        print(' PROTOCOL '.center(70, '='))
-        print('-' * 70)
+        print(' PROTOCOL '.center(70, '='), file=sys.stderr)
+        print('-' * 70, file=sys.stderr)
 
     def test_00_greeting_1_6(self):
         buf = "Tarantool 1.6.6                                                \n" + \

--- a/unit/suites/test_schema.py
+++ b/unit/suites/test_schema.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env ipython
 
+from __future__ import print_function
+
+import sys
 import unittest
 import tarantool
 from .lib.tarantool_server import TarantoolServer
@@ -7,8 +10,8 @@ from .lib.tarantool_server import TarantoolServer
 class TestSuite_Schema(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        print(' SCHEMA '.center(70, '='))
-        print('-' * 70)
+        print(' SCHEMA '.center(70, '='), file=sys.stderr)
+        print('-' * 70, file=sys.stderr)
         self.srv = TarantoolServer()
         self.srv.script = 'unit/suites/box.lua'
         self.srv.start()


### PR DESCRIPTION
It is needed, because all other test output is going to stderr, so
headers we print need to be printed to stderr too.