### PR TITLE
Add TCP_NODELAY back

### DIFF
--- a/tarantool/connection.py
+++ b/tarantool/connection.py
@@ -157,6 +157,7 @@ class Connection(object):
             self._socket = socket.create_connection(
                 (self.host, self.port), timeout=self.connection_timeout)
             self._socket.settimeout(self.socket_timeout)
+            self._socket.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
         except socket.error as e:
             self.connected = False
             raise NetworkError(e)


### PR DESCRIPTION
The connector is synchronous, packets are often small and lack of this
option can lead to delays.

This option was removed in 341c0c17 due to unknown reasons.

Fixes #127.