### PR TITLE
test: use yaml.safe_load() instead of yaml.load()

### DIFF
--- a/test/cluster-py/multi.test.py
+++ b/test/cluster-py/multi.test.py
@@ -42,7 +42,7 @@ for i in range(INSTANCE_N):
 # Make a list of servers
 sources = []
 for server in cluster[1:]:
-    sources.append(yaml.load(server.admin('box.cfg.listen', silent=True))[0])
+    sources.append(yaml.safe_load(server.admin('box.cfg.listen', silent=True))[0])
 
 addrs = []
 for addr in sources:

--- a/unit/suites/lib/tarantool_admin.py
+++ b/unit/suites/lib/tarantool_admin.py
@@ -61,4 +61,4 @@ class TarantoolAdmin(object):
             if (res.rfind("\n...\n") >= 0 or res.rfind("\r\n...\r\n") >= 0):
                 break
 
-        return yaml.load(res)
+        return yaml.safe_load(res)


### PR DESCRIPTION
It eliminates warnings about using unsafe yaml.load(), which was added
to a recent versions of pyyaml. We don't construct Python classes
directly according to yaml tags, so safe_load() fit our needs.

There is even more serious reason to replace yaml.load() usages. In
Gentoo Linux (on recent pyyaml) a call to yaml.load() w/o an explicit
loader causes RuntimeError; see [1].

[1]: https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=79ba924d94cb0cf8559565178414c2a1d687b90c