### PR TITLE
Fix README.rst formatting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,7 @@ Run tests
 On Linux:
 
 .. code-block:: console
+
    $ python setup.py test
 
 On Windows:

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
     license="BSD",
     description="Python client library for Tarantool 1.6 Database",
     long_description=read('README.rst'),
+    long_description_content_type='text/x-rst',
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
Now pypi.org discards a package that does not pass long_description
validation. In our case:

 | The project's long_description has invalid markup which will not be
 | rendered on PyPI. The following syntax errors were detected:
 | line 92: Error: Error in "code-block" directive:
 | maximum 1 argument(s) allowed, 5 supplied.
 |
 | .. code-block:: console
 |    $ python setup.py test

Also added long_description_content_type to eliminate `twine check
dist/*` warning:

 | Checking distribution dist/tarantool-0.6.6.tar.gz: warning:
 | `long_description_content_type` missing.  defaulting to `text/x-rst`.