### PR TITLE
Support msgpack 1.0.0

### DIFF
--- a/tarantool/response.py
+++ b/tarantool/response.py
@@ -54,7 +54,7 @@ class Response(Sequence):
             # Get rid of the following warning.
             # > PendingDeprecationWarning: encoding is deprecated,
             # > Use raw=False instead.
-            unpacker = msgpack.Unpacker(use_list=True, raw=False)
+            unpacker = msgpack.Unpacker(use_list=True, raw=False, strict_map_key=False)
         elif conn.encoding is not None:
             unpacker = msgpack.Unpacker(use_list=True, encoding=conn.encoding)
         else:

--- a/tarantool/response.py
+++ b/tarantool/response.py
@@ -54,11 +54,20 @@ class Response(Sequence):
             # Get rid of the following warning.
             # > PendingDeprecationWarning: encoding is deprecated,
             # > Use raw=False instead.
-            unpacker = msgpack.Unpacker(use_list=True, raw=False, strict_map_key=False)
+            if msgpack.version >= (1, 0, 0):
+                unpacker = msgpack.Unpacker(use_list=True, raw=False, strict_map_key=False)
+            else:
+                unpacker = msgpack.Unpacker(use_list=True, raw=False)
         elif conn.encoding is not None:
-            unpacker = msgpack.Unpacker(use_list=True, encoding=conn.encoding)
+            if msgpack.version >= (1, 0, 0):
+                unpacker = msgpack.Unpacker(use_list=True, encoding=conn.encoding, strict_map_key=False)
+            else:
+                unpacker = msgpack.Unpacker(use_list=True, encoding=conn.encoding)
         else:
-            unpacker = msgpack.Unpacker(use_list=True)
+            if msgpack.version >= (1, 0, 0):
+                unpacker = msgpack.Unpacker(use_list=True, strict_map_key=False)
+            else:
+                unpacker = msgpack.Unpacker(use_list=True)
 
         unpacker.feed(response)
         header = unpacker.unpack()


### PR DESCRIPTION
In msgpack 1.0.0, the default value of strict_map_key is changed to True to avoid hashdos. However, it will break the Tarantool driver, causing an exception: 

```
ValueError: int is not allowed for map key
```

As a result, the driver is unable to parse server response. The issue is reported at https://github.com/tarantool/tarantool-python/issues/155