### PR TITLE
ci: update distributions and target repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,26 @@ deploy:
     on:
       branch: master
       condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_3"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb}
+    skip_cleanup: true
+    on:
+      branch: master
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_4"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb}
+    skip_cleanup: true
+    on:
+      branch: master
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
   # Deploy packages to PackageCloud from tagged revisions
   # https://github.com/tarantool/tarantool/issues/3745
   # https://github.com/travis-ci/travis-ci/issues/7780#issuecomment-302389370
@@ -155,6 +175,26 @@ deploy:
   - provider: packagecloud
     username: tarantool
     repository: "2_2"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb}
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_3"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb}
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_4"
     token: ${PACKAGECLOUD_TOKEN}
     dist: ${OS}/${DIST}
     package_glob: build/*.{rpm,deb}

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,12 @@ env:
       - OS=el DIST=7
       - OS=fedora DIST=28
       - OS=fedora DIST=29
+      - OS=fedora DIST=30
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
       - OS=ubuntu DIST=bionic
+      - OS=ubuntu DIST=eoan
+      - OS=ubuntu DIST=focal
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch
       - OS=debian DIST=buster

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,12 @@ environment:
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python34-x64"
+      # Workaround the build problem [1] by choosing a PyYAML
+      # version for which PyPI provides a wheel for this platform
+      # and Python version / build.
+      #
+      # [1]: http://help.appveyor.com/discussions/problems/28023
+      PYYAML: "==5.2b1"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"
@@ -15,7 +21,7 @@ install:
   # install runtime dependencies
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
   # install testing dependencies
-  - "%PYTHON%\\python.exe -m pip install pyyaml"
+  - "%PYTHON%\\python.exe -m pip install pyyaml%PYYAML%"
 
 build: off
 


### PR DESCRIPTION
Added distributions: Fedora 30, Ubuntu Eoan and Focal.

Added our target repositories: 2_3 and 2_4.

Aside of this, worked around the [problem](http://help.appveyor.com/discussions/problems/28023) that appears on AppVeyor.

Don't added CentOS 8 and Fedora 31 packages, but filed #164 to do it later.