### PR TITLE
msgpack: Add 1.0.0 version support

### DIFF
--- a/tarantool/response.py
+++ b/tarantool/response.py
@@ -50,16 +50,19 @@ class Response(Sequence):
         # created in the __new__().
         # super(Response, self).__init__()
 
+        kwargs = dict(use_list=True)
+        if msgpack.version >= (1, 0, 0):
+            # XXX: Explain why it is necessary.
+            kwargs['strict_map_key'] = False
         if msgpack.version >= (0, 5, 2) and conn.encoding == 'utf-8':
             # Get rid of the following warning.
             # > PendingDeprecationWarning: encoding is deprecated,
             # > Use raw=False instead.
-            unpacker = msgpack.Unpacker(use_list=True, raw=False)
+            kwargs['raw'] = False
         elif conn.encoding is not None:
-            unpacker = msgpack.Unpacker(use_list=True, encoding=conn.encoding)
-        else:
-            unpacker = msgpack.Unpacker(use_list=True)
+            kwargs['encoding'] = conn.encoding
 
+        unpacker = msgpack.Unpacker(**kwargs)
         unpacker.feed(response)
         header = unpacker.unpack()
 


### PR DESCRIPTION
Fix for msgpack version 1.0.0 where `strict_map_key` param was removed.

Please see #155 issue for details.

Since msgpack 1.0.0 was released Unpacker does not have strict_map_key param
and it is True by default now.

It makes the Connector fail with an error: `ValueError: int is not allowed for map key`

The PR contains a fix suggested by @Totktonada [here](https://github.com/tarantool/tarantool-python/pull/156#discussion_r452565743) in the PR #156 which is stuck.

Close related PR #156 please when this one is merged in master.