### PR TITLE
schema: support encoding=None connections

### DIFF
--- a/unit/setup_command.py
+++ b/unit/setup_command.py
@@ -23,7 +23,7 @@ class test(setuptools.Command):
         Find all tests in test/tarantool/ and run them
         '''
 
-        tests = unittest.defaultTestLoader.discover('unit')
+        tests = unittest.defaultTestLoader.discover('unit', pattern='suites')
         test_runner = unittest.TextTestRunner(verbosity=2)
         result = test_runner.run(tests)
         if not result.wasSuccessful():

--- a/unit/suites/__init__.py
+++ b/unit/suites/__init__.py
@@ -4,14 +4,17 @@ import unittest
 __tmp = os.getcwd()
 os.chdir(os.path.abspath(os.path.dirname(__file__)))
 
-from .test_schema import TestSuite_Schema
+from .test_schema import TestSuite_Schema_UnicodeConnection
+from .test_schema import TestSuite_Schema_BinaryConnection
 from .test_dml import TestSuite_Request
 from .test_protocol import TestSuite_Protocol
 from .test_reconnect import TestSuite_Reconnect
 from .test_mesh import TestSuite_Mesh
 
-test_cases = (TestSuite_Schema, TestSuite_Request, TestSuite_Protocol,
-              TestSuite_Reconnect, TestSuite_Mesh)
+test_cases = (TestSuite_Schema_UnicodeConnection,
+              TestSuite_Schema_BinaryConnection,
+              TestSuite_Request, TestSuite_Protocol, TestSuite_Reconnect,
+              TestSuite_Mesh)
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestSuite()

--- a/unit/suites/test_schema.py
+++ b/unit/suites/test_schema.py
@@ -7,15 +7,19 @@ import unittest
 import tarantool
 from .lib.tarantool_server import TarantoolServer
 
-class TestSuite_Schema(unittest.TestCase):
+class TestSuite_Schema_Abstract(unittest.TestCase):
+    # Define 'encoding' field in a concrete class.
+
     @classmethod
     def setUpClass(self):
-        print(' SCHEMA '.center(70, '='), file=sys.stderr)
+        params = 'connection.encoding: {}'.format(repr(self.encoding))
+        print(' SCHEMA ({}) '.format(params).center(70, '='), file=sys.stderr)
         print('-' * 70, file=sys.stderr)
         self.srv = TarantoolServer()
         self.srv.script = 'unit/suites/box.lua'
         self.srv.start()
-        self.con = tarantool.Connection(self.srv.host, self.srv.args['primary'])
+        self.con = tarantool.Connection(self.srv.host, self.srv.args['primary'],
+                                        encoding=self.encoding)
         self.sch = self.con.schema
 
     def setUp(self):
@@ -225,3 +229,11 @@ class TestSuite_Schema(unittest.TestCase):
         self.con.close()
         self.srv.stop()
         self.srv.clean()
+
+
+class TestSuite_Schema_UnicodeConnection(TestSuite_Schema_Abstract):
+    encoding = 'utf-8'
+
+
+class TestSuite_Schema_BinaryConnection(TestSuite_Schema_Abstract):
+    encoding = None

--- a/unit/suites/test_schema.py
+++ b/unit/suites/test_schema.py
@@ -49,6 +49,23 @@ class TestSuite_Schema_Abstract(unittest.TestCase):
                                         encoding=self.encoding)
         self.sch = self.con.schema
 
+        # The relevant test cases mainly target Python 2, where
+        # a user may want to pass a string literal as a space or
+        # an index name and don't bother whether all symbols in it
+        # are ASCII.
+        self.unicode_space_name_literal = '∞'
+        self.unicode_index_name_literal = '→'
+
+        self.unicode_space_name_u = u'∞'
+        self.unicode_index_name_u = u'→'
+        self.unicode_space_id, self.unicode_index_id = self.srv.admin("""
+            do
+                local space = box.schema.create_space('\\xe2\\x88\\x9e')
+                local index = space:create_index('\\xe2\\x86\\x92')
+                return space.id, index.id
+            end
+        """)
+
     def setUp(self):
         # prevent a remote tarantool from clean our session
         if self.srv.is_started():
@@ -72,6 +89,17 @@ class TestSuite_Schema_Abstract(unittest.TestCase):
         res += self.fetch_space_counter.call_count()
         res += self.fetch_index_counter.call_count()
         return res
+
+    def verify_unicode_space(self, space):
+        self.assertEqual(space.sid, self.unicode_space_id)
+        self.assertEqual(space.name, self.unicode_space_name_u)
+        self.assertEqual(space.arity, 1)
+
+    def verify_unicode_index(self, index):
+        self.assertEqual(index.space.name, self.unicode_space_name_u)
+        self.assertEqual(index.iid, self.unicode_index_id)
+        self.assertEqual(index.name, self.unicode_index_name_u)
+        self.assertEqual(len(index.parts), 1)
 
     def test_00_authenticate(self):
         self.assertIsNone(self.srv.admin("box.schema.user.create('test', { password = 'test' })"))
@@ -122,6 +150,9 @@ class TestSuite_Schema_Abstract(unittest.TestCase):
         self.assertEqual(space.name, '_index')
         self.assertEqual(space.arity, 1)
 
+        space = self.sch.get_space(self.unicode_space_name_literal)
+        self.verify_unicode_space(space)
+
     def test_03_02_space_number(self):
         self.con.flush_schema()
         space = self.sch.get_space(272)
@@ -137,6 +168,9 @@ class TestSuite_Schema_Abstract(unittest.TestCase):
         self.assertEqual(space.name, '_index')
         self.assertEqual(space.arity, 1)
 
+        space = self.sch.get_space(self.unicode_space_id)
+        self.verify_unicode_space(space)
+
     def test_04_space_cached(self):
         space = self.sch.get_space('_schema')
         self.assertEqual(space.sid, 272)
@@ -150,6 +184,12 @@ class TestSuite_Schema_Abstract(unittest.TestCase):
         self.assertEqual(space.sid, 288)
         self.assertEqual(space.name, '_index')
         self.assertEqual(space.arity, 1)
+
+        # Verify that no schema fetches occurs.
+        self.assertEqual(self.fetch_count, 0)
+
+        space = self.sch.get_space(self.unicode_space_name_literal)
+        self.verify_unicode_space(space)
 
         # Verify that no schema fetches occurs.
         self.assertEqual(self.fetch_count, 0)
@@ -177,6 +217,10 @@ class TestSuite_Schema_Abstract(unittest.TestCase):
         self.assertEqual(index.name, 'name')
         self.assertEqual(len(index.parts), 1)
 
+        index = self.sch.get_index(self.unicode_space_name_literal,
+                                   self.unicode_index_name_literal)
+        self.verify_unicode_index(index)
+
     def test_05_02_index_name___number(self):
         self.con.flush_schema()
         index = self.sch.get_index('_index', 0)
@@ -199,6 +243,10 @@ class TestSuite_Schema_Abstract(unittest.TestCase):
         self.assertEqual(index.iid, 2)
         self.assertEqual(index.name, 'name')
         self.assertEqual(len(index.parts), 1)
+
+        index = self.sch.get_index(self.unicode_space_name_literal,
+                                   self.unicode_index_id)
+        self.verify_unicode_index(index)
 
     def test_05_03_index_number_name__(self):
         self.con.flush_schema()
@@ -223,6 +271,10 @@ class TestSuite_Schema_Abstract(unittest.TestCase):
         self.assertEqual(index.name, 'name')
         self.assertEqual(len(index.parts), 1)
 
+        index = self.sch.get_index(self.unicode_space_id,
+                                   self.unicode_index_name_literal)
+        self.verify_unicode_index(index)
+
     def test_05_04_index_number_number(self):
         self.con.flush_schema()
         index = self.sch.get_index(288, 0)
@@ -246,6 +298,10 @@ class TestSuite_Schema_Abstract(unittest.TestCase):
         self.assertEqual(index.name, 'name')
         self.assertEqual(len(index.parts), 1)
 
+        index = self.sch.get_index(self.unicode_space_id,
+                                   self.unicode_index_id)
+        self.verify_unicode_index(index)
+
     def test_06_index_cached(self):
         index = self.sch.get_index('_index', 'primary')
         self.assertEqual(index.space.name, '_index')
@@ -267,6 +323,19 @@ class TestSuite_Schema_Abstract(unittest.TestCase):
         self.assertEqual(index.iid, 2)
         self.assertEqual(index.name, 'name')
         self.assertEqual(len(index.parts), 1)
+
+        # Verify that no schema fetches occurs.
+        self.assertEqual(self.fetch_count, 0)
+
+        cases = (
+            (self.unicode_space_name_literal, self.unicode_index_name_literal),
+            (self.unicode_space_name_literal, self.unicode_index_id),
+            (self.unicode_space_id, self.unicode_index_name_literal),
+            (self.unicode_space_id, self.unicode_index_id),
+        )
+        for s, i in cases:
+            index = self.sch.get_index(s, i)
+            self.verify_unicode_index(index)
 
         # Verify that no schema fetches occurs.
         self.assertEqual(self.fetch_count, 0)


### PR DESCRIPTION
Several different problems are fixed here, but all have the same root.
When a connection encoding is None (it is default on Python 2 and may be
set explicitly on Python 3), all mp_str values are decoded into bytes,
not Unicode strings (note that bytes is alias for str in Python 2). But
the database schema parsing code have assumptions that _vspace / _vindex
values are Unicode strings.

The resolved problems are the following:

1. Default encoding in bytes#decode() method is 'ascii', however names
   in tarantool can contain symbols beyond ASCII symbol table. Set
   'utf-8' for names decoding.
2. Convert all binary values into Unicode strings before parse or store
   them. This allows further correct accesses to the local schema
   representation.
3. Convert binary parameters like space, index or field name into
   Unicode strings, when a schema is accessed to don't trigger redundant
   schema refetching.

Those problems are briefly mentioned in [1].

Tested manually with Python 2 and Python 3: my testing tarantool
instance has a space with name '©' and after the changes I'm able to
connect to it when the connection encoding is set to None. Also I
verified that schema is not fetched each time when I do
\<connection\>.select('©') in Python 2 (where such string literal is str /
bytes, not Unicode string).

Added relevant test cases as separate commits within the PR.

[1]: https://github.com/tarantool/tarantool-python/issues/105#issuecomment-630907601