### PR TITLE
pypi: correct msgpack library name, bump 0.7.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+tarantool-python (0.7.1-0) unstable; urgency=medium
+
+    ## Overview
+
+    It is pure technical release. It fixes the dependency on the msgpack
+    library.
+
+ -- Alexander Turenko <alexander.turenko@tarantool.org> Mon, 28 Dec 2020 04:01:30 +0300
+
 tarantool-python (0.7.0-0) unstable; urgency=medium
 
     ## Overview

--- a/rpm/tarantool-python.spec
+++ b/rpm/tarantool-python.spec
@@ -1,6 +1,6 @@
 Summary: Python client library for Tarantool Database
 Name: tarantool-python
-Version: 0.7.0
+Version: 0.7.1
 Release: 1%{?dist}
 Source0: tarantool-python-%{version}.tar.gz
 License: BSD

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,6 @@ setup(
     cmdclass=cmdclass,
     command_options=command_options,
     install_requires=[
-        'msgpack-python>=0.4',
+        'msgpack>=0.4.0',
     ]
 )

--- a/tarantool/__init__.py
+++ b/tarantool/__init__.py
@@ -25,7 +25,7 @@ from tarantool.utils import (
     ENCODING_DEFAULT
 )
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 
 def connect(host="localhost", port=33013, user=None, password=None,


### PR DESCRIPTION
In short, the msgpack library changes its name and now offered as
'msgpack' rather than 'msgpack-python'. All new versions of the library
are shipped under the new name, so we should change our dependency
information.

See commit 148d12ea5dc4e999107211227a4da5f5a67bf62c ('travis-ci: verify
different msgpack library versions') for details.

Bump version to 0.7.1.

Follows up #155
Follows up #183