### PR TITLE
python3: make json.dumps compatible with Python 2

### DIFF
--- a/tarantool/response.py
+++ b/tarantool/response.py
@@ -263,7 +263,7 @@ class Response(Sequence):
                     'code': self.strerror[0],
                     'reason': self.return_message
                 }
-            }, sort_keys = True, indent = 4)
+            }, sort_keys = True, indent = 4, separators=(', ', ': '))
         output = []
         for tpl in self._data or ():
             output.extend(("- ", repr(tpl), "\n"))


### PR DESCRIPTION
Python 3.4: Changed in version 3.4: Use (',', ': ') as default if
indent is not None. This behaviour broke a test box-py/call.test.py.

1. https://docs.python.org/3/library/json.html#json.dump