### PR TITLE
python3: make conversion to string deterministic

### DIFF
--- a/tarantool/response.py
+++ b/tarantool/response.py
@@ -29,6 +29,25 @@ from tarantool.error import (
     tnt_strerror
 )
 
+def deep_convert_dict(obj):
+    if isinstance(obj, dict):
+        ret = []
+        for k, v in sorted(obj.items()):
+            if hasattr(v, '__getitem__'):
+                ret.append((k, deep_convert_dict(v)))
+            else:
+                ret.append((k, v))
+        return ret
+    if isinstance(obj, list):
+        ret = []
+        for v in obj:
+            if hasattr(v, '__getitem__'):
+                ret.append(deep_convert_dict(v))
+            else:
+                ret.append(v)
+        return ret
+    else:
+        return obj
 
 class Response(Sequence):
     '''
@@ -266,6 +285,7 @@ class Response(Sequence):
             }, sort_keys = True, indent = 4, separators=(', ', ': '))
         output = []
         for tpl in self._data or ():
+            tpl = deep_convert_dict(tpl)
             output.extend(("- ", repr(tpl), "\n"))
         if len(output) > 0:
             output.pop()


### PR DESCRIPTION
Response object is a unpacked msgpack structure, returned by Tarantool.
Nor msgpack-python [1] that used in tarantool-python nor msgpack [2]
itself cannot guarantee an order of keys in unpacked dictionaries.
Therefore we have different keys order with running tests under Python 2
and Python 3, for example box-py/call.test.py. To workaround a problem
proposed a conversion of dictionaries in a tuple to lists before
printing Response object.

1. https://github.com/msgpack/msgpack-python/pull/164
2. https://github.com/msgpack/msgpack/issues/215