### PR TITLE
github-ci: add reusable testing workflow

### DIFF
--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -1,0 +1,42 @@
+name: reusable_testing
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: The name of the tarantool build artifact
+        default: ubuntu-focal
+        required: false
+        type: string
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone the tarantool-python connector
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository_owner }}/tarantool-python
+
+      - name: Download the tarantool build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ inputs.artifact_name }}
+
+      - name: Install tarantool
+        # Now we're lucky: all dependencies are already installed. Check package
+        # dependencies when migrating to other OS version.
+        run: sudo dpkg -i tarantool*.deb
+
+      - name: Setup python3 for tests
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Install connector requirements
+        run: pip install -r requirements.txt
+
+      - name: Install test requirements
+        run: pip install -r requirements-test.txt
+
+      - run: make test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,6 @@ environment:
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python34-x64"
-      # Workaround the build problem [1] by choosing a PyYAML
-      # version for which PyPI provides a wheel for this platform
-      # and Python version / build.
-      #
-      # [1]: http://help.appveyor.com/discussions/problems/28023
-      PYYAML: "==5.2b1"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"
@@ -23,7 +17,7 @@ install:
   # install runtime dependencies
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
   # install testing dependencies
-  - "%PYTHON%\\python.exe -m pip install pyyaml%PYYAML% dbapi-compliance==1.15.0"
+  - "%PYTHON%\\python.exe -m pip install -r requirements-test.txt"
 
 build: off
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+dbapi-compliance==1.15.0
+# Use this pyyaml version to be compatible with Python34-x64 on Windows.
+# See for more details http://help.appveyor.com/discussions/problems/28023.
+pyyaml==5.2b1


### PR DESCRIPTION
The idea of this workflow is to be a part of the 'integration.yml'
workflow from the tarantool repo to verify the integration of the
tarantool-python connector with an arbitrary tarantool version.

This workflow is not triggered on a push to the repo and cannot be run
manually since it has only the 'workflow_call' trigger. This workflow
will be included in the tarantool development cycle and called by the
'integration.yml' workflow from the tarantool project on a push to the
master and release branches for verifying integration of tarantool with
tarantool-python.

Part of tarantool/tarantool#6584
Part of tarantool/tarantool#5265
Part of tarantool/tarantool#6056

Related to tarantool/tarantool#6590