### PR TITLE
Skip SQL tests if tarantool version < 2.0.0

### DIFF
--- a/test/suites/lib/skip.py
+++ b/test/suites/lib/skip.py
@@ -1,0 +1,43 @@
+import functools
+import pkg_resources
+import re
+
+SQL_SUPPORT_TNT_VERSION = '2.0.0'
+
+
+def skip_or_run_sql_test(func):
+    """Decorator to skip or run SQL-related tests depending on the tarantool
+    version.
+
+    Tarantool supports SQL-related stuff only since 2.0.0 version. So this
+    decorator should wrap every SQL-related test to skip it if the tarantool
+    version < 2.0.0 is used for testing.
+
+    Also, it can be used with the 'setUp' method for skipping the whole test
+    suite.
+    """
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        if func.__name__ == 'setUp':
+            func(self, *args, **kwargs)
+
+        if not hasattr(self, 'tnt_version'):
+            self.__class__.tnt_version = re.match(
+                r'[\d.]+', self.srv.admin('box.info.version')[0]
+            ).group()
+
+        tnt_version = pkg_resources.parse_version(self.tnt_version)
+        sql_support_tnt_version = pkg_resources.parse_version(
+            SQL_SUPPORT_TNT_VERSION
+        )
+
+        if tnt_version < sql_support_tnt_version:
+            self.skipTest(
+                'Tarantool %s does not support SQL' % self.tnt_version
+            )
+
+        if func.__name__ != 'setUp':
+            func(self, *args, **kwargs)
+
+    return wrapper

--- a/test/suites/test_dbapi.py
+++ b/test/suites/test_dbapi.py
@@ -10,6 +10,7 @@ import dbapi20
 import tarantool
 from tarantool import dbapi
 from .lib.tarantool_server import TarantoolServer
+from .lib.skip import skip_or_run_sql_test
 
 
 class TestSuite_DBAPI(dbapi20.DatabaseAPI20Test):
@@ -34,6 +35,7 @@ class TestSuite_DBAPI(dbapi20.DatabaseAPI20Test):
             host=self.srv.host,
             port=self.srv.args['primary'])
 
+    @skip_or_run_sql_test
     def setUp(self):
         # prevent a remote tarantool from clean our session
         if self.srv.is_started():

--- a/test/suites/test_execute.py
+++ b/test/suites/test_execute.py
@@ -7,11 +7,12 @@ import unittest
 
 import tarantool
 from .lib.tarantool_server import TarantoolServer
+from .lib.skip import skip_or_run_sql_test
 
 
 class TestSuite_Execute(unittest.TestCase):
     ddl = 'create table %s (id INTEGER PRIMARY KEY AUTOINCREMENT, ' \
-           'name varchar(20))'
+          'name varchar(20))'
 
     dml_params = [
         {'id': None, 'name': 'Michael'},
@@ -30,6 +31,7 @@ class TestSuite_Execute(unittest.TestCase):
         self.srv.start()
         self.con = tarantool.Connection(self.srv.host, self.srv.args['primary'])
 
+    @skip_or_run_sql_test
     def setUp(self):
         # prevent a remote tarantool from clean our session
         if self.srv.is_started():


### PR DESCRIPTION
Problem: all SQL-related tests fail with the following error
if tarantool < 2.0.0 is used:

    tarantool.error.DatabaseError: (48, 'Unknown request type 11')

Tarantool supports SQL-related stuff only since the 2.0.0 version.
So this patch adds a special decorator that will skip the test if
tarantool version < 2.0.0 is used.

Fixes #194