### PR TITLE
doc: clarify license of the project (BSD-2-Clause)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,35 @@
+In the order of a first contribution.
+
+Konstantin Cherkasoff <k.cherkasoff@gmail.com>
+Roman Tsisyk <roman@tsisyk.com>
+Vlad Emelyanov <volshebnyi@gmail.com>
+Dmitry E. Oboukhov <unera@debian.org>
+Eugine Blikh <bigbes@gmail.com>
+Sokolov Yura <funny.falcon@gmail.com>
+Konstantin Osipov <kostja@tarantool.org>
+Andrey Drozdov <sulverus@gmail.com>
+Alexander <xhaskx@gmail.com>
+Vladimir Rudnyh <rudnyh@corp.mail.ru>
+Dmitry Shveenkov <shveenkov@mail.ru>
+Nikolay Meleshenko <ko91h7@gmail.com>
+Alexander Abashkin <monolithed@gmail.com>
+Nick Zavaritsky <mejedi@gmail.com>
+Mikhail Kaplenko
+Vladimir Marunov <v.marunov@gmail.com>
+Zajcev Evgeny <zevlg@yandex.ru>
+Konstantin Nazarov <mail@racktear.com>
+Ilya Markov <markovilya197@gmail.com>
+Dmitry Zimnukhov <zimnuhov@gmail.com>
+Alexey Gadzhiev <alexey.gadzhiev@corp.mail.ru>
+Konstantin Belyavskiy <k.belyavskiy@tarantool.org>
+Michael Filonenko <filonenko.mikhail@gmail.com>
+Alexander Turenko <alexander.turenko@tarantool.org>
+Sergei Voronezhskii <sergw@tarantool.org>
+Alexander V. Tikhonov <avtikhon@tarantool.org>
+Oleg Babin <babinoleg@mail.ru>
+Denis Ignatenko <denis.ignatenko@gmail.com>
+Ilya Konyukhov <runsfor@gmail.com>
+Vladislav Shpilevoy <v.shpilevoy@tarantool.org>
+Artem Morozov <artembo@me.com>
+Sergey Bronnikov <sergeyb@tarantool.org>
+Yaroslav Lobankov <y.lobankov@tarantool.org>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+Copyright 2011-2022 tarantool-python AUTHORS: please see the AUTHORS file.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.rst
+++ b/README.rst
@@ -117,3 +117,8 @@ On Windows:
 .. _`BSD-2-Clause`: https://opensource.org/licenses/BSD-2-Clause
 .. _`asynctnt`: https://github.com/igorcoding/asynctnt
 .. _`feature comparison table`: https://www.tarantool.io/en/doc/latest/book/connectors/#python-feature-comparison
+
+License
+^^^^^^^
+
+BSD-2-Clause. See the ``LICENSE`` file.


### PR DESCRIPTION
Updated the readme file, added a license file, added an authors file.

Also clarified that tarantool's license is BSD-2-Clause: it was referred as BSD-3-Clause by a mistake.

Fixes #197