### PR TITLE
Introduce GitHub CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,167 @@
+name: testing
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  run_tests_linux:
+    # We want to run on external PRs, but not on our own internal
+    # PRs as they'll be run by the push to the branch.
+    #
+    # The main trick is described here:
+    # https://github.com/Dart-Code/Dart-Code/pull/2375
+    if: github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository
+
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        tarantool:
+          - '1.10'
+          - '2.8'
+          - '2.x-latest'
+        python:
+          - '2.7'
+          - '3.5'
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+        msgpack-deps:
+          # latest msgpack will be installed as a part of requirements.txt
+          - ''
+
+        # Adding too many elements to three-dimentional matrix results in
+        # too many test cases. It causes GitHub webpages to fail with 
+        # "This page is taking too long to load." error. Thus we use
+        # pairwise testing.
+        include:
+          - tarantool: '2.8'
+            python: '3.10'
+            msgpack-deps: 'msgpack-python==0.4.0'
+          - tarantool: '2.8'
+            python: '3.10'
+            msgpack-deps: 'msgpack==0.5.0'
+          - tarantool: '2.8'
+            python: '3.10'
+            msgpack-deps: 'msgpack==0.6.2'
+          - tarantool: '2.8'
+            python: '3.10'
+            msgpack-deps: 'msgpack==1.0.0'
+
+    steps:
+      - name: Clone the connector
+        uses: actions/checkout@v2
+
+      - name: Install tarantool ${{ matrix.tarantool }}
+        if: matrix.tarantool != '2.x-latest'
+        uses: tarantool/setup-tarantool@v1
+        with:
+          tarantool-version: ${{ matrix.tarantool }}
+
+      - name: Install latest tarantool 2.x
+        if: matrix.tarantool == '2.x-latest'
+        run: |
+          curl -L https://tarantool.io/pre-release/2/installer.sh | sudo bash
+          sudo apt install -y tarantool tarantool-dev
+
+      - name: Setup Python for tests
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install specific version of msgpack package
+        if: startsWith(matrix.msgpack-deps, 'msgpack==') == true
+        run: |
+          pip install ${{ matrix.msgpack-deps }}
+
+      - name: Install specific version of msgpack-python package
+        # msgpack package is a replacement for deprecated msgpack-python.
+        # To test compatibility with msgpack-python we must ignore
+        # requirements.txt install of msgpack package by overwriting it
+        # with sed.
+        if: startsWith(matrix.msgpack-deps, 'msgpack-python==') == true
+        run: |
+          pip install ${{ matrix.msgpack-deps }}
+          sed -i -e "s/^msgpack.*$/${{ matrix.msgpack-deps }}/" requirements.txt
+
+      - name: Install package requirements
+        run: pip install -r requirements.txt
+
+      - name: Install test requirements
+        run: pip install -r requirements-test.txt
+
+      - name: Run tests
+        run: make test
+
+  run_tests_windows:
+    # We want to run on external PRs, but not on our own internal
+    # PRs as they'll be run by the push to the branch.
+    #
+    # The main trick is described here:
+    # https://github.com/Dart-Code/Dart-Code/pull/2375
+    if: github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository
+
+    runs-on: windows-2022
+
+    strategy:
+      fail-fast: false
+      matrix:
+        tarantool:
+          - '1.10'
+          - '2.8'
+        python:
+          - '2.7'
+          - '3.10'
+
+    steps:
+      - name: Clone the connector
+        uses: actions/checkout@v2
+
+      - name: Setup Python for tests
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install connector requirements
+        run: pip install -r requirements.txt
+
+      - name: Install test requirements
+        run: pip install -r requirements-test.txt
+
+      - name: Setup WSL for tarantool
+        uses: Vampire/setup-wsl@v1
+        with:
+          distribution: Ubuntu-20.04
+
+      - name: Install tarantool ${{ matrix.tarantool }} for WSL
+        shell: wsl-bash_Ubuntu-20.04 {0}
+        run: |
+          curl -L https://tarantool.io/installer.sh | VER=${{ matrix.tarantool }} bash -s -- --type "release"
+          sudo apt install -y tarantool tarantool-dev
+
+      - name: Setup test tarantool instance
+        shell: wsl-bash_Ubuntu-20.04 {0}
+        run: |
+          rm -f ./tarantool.pid ./tarantool.log
+          TNT_PID=$(tarantool ./test/suites/lib/tarantool_python_ci.lua > tarantool.log 2>&1 & echo $!)
+          touch tarantool.pid
+          echo $TNT_PID > ./tarantool.pid
+
+      - name: Run tests
+        env:
+          REMOTE_TARANTOOL_HOST: localhost
+          REMOTE_TARANTOOL_CONSOLE_PORT: 3302
+        run: make test
+
+      - name: Stop test tarantool instance
+        if: ${{ always() }}
+        shell: wsl-bash_Ubuntu-20.04 {0}
+        run: |
+          cat tarantool.log || true
+          kill $(cat tarantool.pid) || true

--- a/README.rst
+++ b/README.rst
@@ -11,11 +11,8 @@ This package is a pure-python client library for `Tarantool`_.
 .. _`GitHub`: https://github.com/tarantool/tarantool-python
 .. _`Issue tracker`: https://github.com/tarantool/tarantool-python/issues
 
-.. image:: https://travis-ci.org/tarantool/tarantool-python.svg?branch=master
-    :target: https://travis-ci.org/tarantool/tarantool-python
-
-.. image:: https://ci.appveyor.com/api/projects/status/github/tarantool/tarantool-python?branch=master
-    :target: https://ci.appveyor.com/project/tarantool/tarantool-python
+.. image:: https://github.com/tarantool/tarantool-python/actions/workflows/testing.yml/badge.svg?branch=master
+    :target: https://github.com/tarantool/tarantool-python/actions/workflows/testing.yml
 
 Download and Install
 --------------------

--- a/test/suites/test_dml.py
+++ b/test/suites/test_dml.py
@@ -146,6 +146,9 @@ class TestSuite_Request(unittest.TestCase):
         # Simple ping test
         # * No exceptions are raised
         # * Ping time > 0
+        if sys.platform.startswith("win"):
+            self.skipTest("Windows clock precision causes test to fail sometimes, see #214")
+
         self.assertTrue(self.con.ping() > 0)
         self.assertEqual(self.con.ping(notime=True), "Success")
 


### PR DESCRIPTION
### Setup GitHub Actions testing pipeline

Before this patch, tarantool/tarantool-python CI was based on Travis CI (Linux runs) and Appveyor (Windows runs). This PR introduces GitHub Actions workflow files for both Linux and Windows test runs. Pipelines run for different supported tarantool, Python and msgpack package versions to ensure compatibility. tarantool instance is started in each Windows pipeline under WSL to run tests instead of using an external server (like in Appveyor). Since we start a new tarantool instance for each run, `clean()` procedure was removed. (The main reason to remove it was failing with `ER_DROP_FUNCTION: Can't drop function 1:
function is SQL built-in` error on newer 2.x on bootstrap.)

Testing pipeline for tarantool artifacts was also updated.

Travis CI and Appveyor badges were replaced with GitHub Actions badge.

### Skip flaky ping test on Windows

Ping test started to fail (in ~70% cases) after Windows CI migration from Appveyor to GitHub Actions. As a part of this migration, the test tarantool instance was changed from an instance started on a remote Linux server to an instance started on the same Windows server under WSL. Thus, request time has shortened and it supposedly caused the ping test to fail.

Python [documentation](https://docs.python.org/3/library/time.html#time.time) declares that

> ...though the time is always returned as a floating point number,
> not all systems provide time with a better precision than 1 second...

Particularly, this[ StackOverflow answer](https://stackoverflow.com/a/1938096/11646599) argues that

> For Linux and Mac precision is +- 1 microsecond or 0.001 milliseconds.
> Python on Windows uses +- 16 milliseconds precision due to clock
> implementation problems due to process interrupts.

based on Windows [documentation](https://docs.microsoft.com/en-us/windows-hardware/drivers/kernel/high-resolution-timers) [3].

Assuming that ping requests between the same server services can easilybe under 1 ms, it caused the test to fail.

This patch adds skip for the flaky test, refer to #214 for further development.

Closes #182, part of #214

After merging this PR, Appveyor workflows must be removed since they are not useful anymore.
