### PR TITLE
readme: update version in header and fix formatting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-Python driver for Tarantool 1.6
-===============================
+Python driver for Tarantool
+===========================
 
 This package is a pure-python client library for `Tarantool`_.
 

--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,10 @@ Features
 * Lua packages for non-blocking I/O, fibers and HTTP
 * MsgPack data format and MsgPack based client-server protocol
 * Two data engines:
+
   * memtx - the in-memory storage engine with optional persistence
   * vinyl - the on-disk storage engine to use with large data sets
+
 * secondary key and index iterators support (can be non-unique and composite)
 * multiple index types: HASH, BITSET, TREE, RTREE
 * asynchronous master-master replication


### PR DESCRIPTION
We don't need to explicitly set a version of Tarantool in header because
it may confuse Tarantool users. Python connector supports Tarantool with
versions below and upper version 1.6.0. The section below describes more
details about compatibility of Tarantool and connector versions. The first patch
removes a version in the header.

The second patch fixes items in a list.