### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- SSL support (PR #220, #217).
-- Tarantool Enterprise testing workflow on GitHub actions (PR #220).
 
 ### Changed
 
 ### Fixed
+
+## 0.9.0 - 2022-06-20
+
+### Added
+- SSL support (PR #220, #217).
+- Tarantool Enterprise testing workflow on GitHub actions (PR #220).
 
 ## 0.8.0 - 2022-04-29
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,107 @@
+tarantool-python (0.9.0-0) unstable; urgency=medium
+    ## Overview
+
+    This release features SSL support.
+
+    To use encrypted connection with Tarantool Enterprise Edition
+    instance, pass "ssl" `transport` parameter on connect:
+
+    ```python
+    con = tarantool.Connection(
+        host, port,
+        user=user,
+        password=pass,
+        transport="ssl")
+    ```
+
+    To verify the server, set client trusted certificate
+    authorities (CA) file with `ssl_ca_file` parameter:
+
+    ```python
+    con = tarantool.Connection(
+        host, port,
+        user=user,
+        password=password,
+        transport="ssl",
+        ssl_ca_file=client_ca_file)
+    ```
+    
+    If the server authenticates clients using certificates issued by
+    given CA, you must provide private SSL key file with `ssl_key_file`
+    parameter and SSL certificate file with `ssl_cert_file` parameter.
+    Otherwise, these parameters are optional.
+
+    ```python
+    con = tarantool.Connection(
+        host, port,
+        user=user,
+        password=password,
+        transport="ssl",
+        ssl_key_file=client_key_file,
+        ssl_cert_file=client_cert_file)
+    ```
+
+    To set SSL ciphers, set them with `ssl_ciphers` parameter as
+    a colon-separated (:) string:
+
+    ```python
+    con = tarantool.Connection(
+        host, port,
+        user=user,
+        password=password,
+        transport="ssl",
+        ssl_ciphers=client_ssl_ciphers)
+    ```
+
+    ConnectionPool and MeshConnection also support these parameters.
+
+    ```python
+    mesh = tarantool.MeshConnection(
+        addrs={
+            "host": host,
+            "post": port,
+            "transport": "ssl",
+            "ssl_key_file": client_key_file,
+            "ssl_cert_file": client_cert_file,
+            "ssl_ca_file": client_ca_file,
+            "ssl_ciphers": client_ssl_ciphers,
+        },
+        user=user,
+        password=password)
+    ```
+
+    ```python
+    pool = tarantool.ConnectionPool(
+        addrs={
+            "host": host,
+            "post": port,
+            "transport": "ssl",
+            "ssl_key_file": client_key_file,
+            "ssl_cert_file": client_cert_file,
+            "ssl_ca_file": client_ca_file,
+            "ssl_ciphers": client_ssl_ciphers,
+        },
+        user=user,
+        password=password)
+    ```
+
+    See [Tarantool Enterprise Edition manual](https://www.tarantool.io/en/enterprise_doc/security/#enterprise-iproto-encryption)
+    for details. 
+
+    ## Breaking changes
+
+    There are no breaking changes in the release.
+
+    ## New features
+
+    * SSL support (PR #220, #217).
+
+    ## Testing
+
+    * Tarantool Enterprise testing workflow on GitHub actions (PR #220).
+
+ -- Georgy Moiseev <georgy.moiseev@tarantool.org> Mon, 20 Jun 2022 18:00:00 +0300
+
 tarantool-python (0.8.0-0) unstable; urgency=medium
 
     ## Overview

--- a/rpm/tarantool-python.spec
+++ b/rpm/tarantool-python.spec
@@ -1,6 +1,6 @@
 Summary: Python client library for Tarantool Database
 Name: tarantool-python
-Version: 0.8.0
+Version: 0.9.0
 Release: 1%{?dist}
 Source0: tarantool-python-%{version}.tar.gz
 License: BSD

--- a/tarantool/__init__.py
+++ b/tarantool/__init__.py
@@ -9,6 +9,11 @@ from tarantool.const import (
     SOCKET_TIMEOUT,
     RECONNECT_MAX_ATTEMPTS,
     RECONNECT_DELAY,
+    DEFAULT_TRANSPORT,
+    DEFAULT_SSL_KEY_FILE,
+    DEFAULT_SSL_CERT_FILE,
+    DEFAULT_SSL_CA_FILE,
+    DEFAULT_SSL_CIPHERS
 )
 
 from tarantool.error import (
@@ -24,14 +29,18 @@ from tarantool.schema import (
 )
 
 from tarantool.utils import (
-    ENCODING_DEFAULT
+    ENCODING_DEFAULT,
 )
 
 __version__ = "0.8.0"
 
 
 def connect(host="localhost", port=33013, user=None, password=None,
-            encoding=ENCODING_DEFAULT):
+            encoding=ENCODING_DEFAULT, transport=DEFAULT_TRANSPORT,
+            ssl_key_file=DEFAULT_SSL_KEY_FILE,
+            ssl_cert_file=DEFAULT_SSL_CERT_FILE,
+            ssl_ca_file=DEFAULT_SSL_CA_FILE,
+            ssl_ciphers=DEFAULT_SSL_CIPHERS):
     '''
     Create a connection to the Tarantool server.
 
@@ -50,7 +59,12 @@ def connect(host="localhost", port=33013, user=None, password=None,
                       reconnect_max_attempts=RECONNECT_MAX_ATTEMPTS,
                       reconnect_delay=RECONNECT_DELAY,
                       connect_now=True,
-                      encoding=encoding)
+                      encoding=encoding,
+                      transport=transport,
+                      ssl_key_file=ssl_key_file,
+                      ssl_cert_file=ssl_cert_file,
+                      ssl_ca_file=ssl_ca_file,
+                      ssl_ciphers=ssl_ciphers)
 
 
 def connectmesh(addrs=({'host': 'localhost', 'port': 3301},), user=None,

--- a/tarantool/__init__.py
+++ b/tarantool/__init__.py
@@ -32,7 +32,7 @@ from tarantool.utils import (
     ENCODING_DEFAULT,
 )
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 
 def connect(host="localhost", port=33013, user=None, password=None,


### PR DESCRIPTION
### Overview

This release features SSL support.

To use encrypted connection with Tarantool Enterprise Edition
instance, pass "ssl" `transport` parameter on connect:

```python
con = tarantool.Connection(
    host, port,
    user=user,
    password=pass,
    transport="ssl")
```

To verify the server, set client trusted certificate
authorities (CA) file with `ssl_ca_file` parameter:

```python
con = tarantool.Connection(
    host, port,
    user=user,
    password=password,
    transport="ssl",
    ssl_ca_file=client_ca_file)
```

If the server authenticates clients using certificates issued by
given CA, you must provide private SSL key file with `ssl_key_file`
parameter and SSL certificate file with `ssl_cert_file` parameter.
Otherwise, these parameters are optional.

```python
con = tarantool.Connection(
    host, port,
    user=user,
    password=password,
    transport="ssl",
    ssl_key_file=client_key_file,
    ssl_cert_file=client_cert_file)
```

To set SSL ciphers, set them with `ssl_ciphers` parameter as
a colon-separated (:) string:

```python
con = tarantool.Connection(
    host, port,
    user=user,
    password=password,
    transport="ssl",
    ssl_ciphers=client_ssl_ciphers)
```

ConnectionPool and MeshConnection also support these parameters.

```python
mesh = tarantool.MeshConnection(
    addrs={
        "host": host,
        "post": port,
        "transport": "ssl",
        "ssl_key_file": client_key_file,
        "ssl_cert_file": client_cert_file,
        "ssl_ca_file": client_ca_file,
        "ssl_ciphers": client_ssl_ciphers,
    },
    user=user,
    password=password)
```

```python
pool = tarantool.ConnectionPool(
    addrs={
        "host": host,
        "post": port,
        "transport": "ssl",
        "ssl_key_file": client_key_file,
        "ssl_cert_file": client_cert_file,
        "ssl_ca_file": client_ca_file,
        "ssl_ciphers": client_ssl_ciphers,
    },
    user=user,
    password=password)
```

See [Tarantool Enterprise Edition manual](https://www.tarantool.io/en/enterprise_doc/security/#enterprise-iproto-encryption)
for details. 

### Breaking changes

There are no breaking changes in the release.

### New features

* SSL support (PR #220, #217).

### Testing

* Tarantool Enterprise testing workflow on GitHub actions (PR #220).