### PR TITLE
api: any msgpack supported type as a request key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Package build (#238).
+- Allow any MessagePack supported type as a request key (#240).
 
 ## 0.9.0 - 2022-06-20
 

--- a/tarantool/connection.py
+++ b/tarantool/connection.py
@@ -86,9 +86,9 @@ from tarantool.error import (
 )
 from tarantool.schema import Schema
 from tarantool.utils import (
-    check_key,
     greeting_decode,
     version_id,
+    wrap_key,
     ENCODING_DEFAULT,
 )
 
@@ -1220,7 +1220,7 @@ class Connection(ConnectionInterface):
         .. _delete: https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_space/delete/
         """
 
-        key = check_key(key)
+        key = wrap_key(key)
         if isinstance(space_name, str):
             space_name = self.schema.get_space(space_name).sid
         if isinstance(index, str):
@@ -1349,7 +1349,7 @@ class Connection(ConnectionInterface):
         .. _update: https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_space/update/
         """
 
-        key = check_key(key)
+        key = wrap_key(key)
         if isinstance(space_name, str):
             space_name = self.schema.get_space(space_name).sid
         if isinstance(index, str):
@@ -1534,7 +1534,7 @@ class Connection(ConnectionInterface):
 
         # Perform smart type checking (scalar / list of scalars / list of
         # tuples)
-        key = check_key(key, select=True)
+        key = wrap_key(key, select=True)
 
         if isinstance(space_name, str):
             space_name = self.schema.get_space(space_name).sid

--- a/tarantool/utils.py
+++ b/tarantool/utils.py
@@ -1,8 +1,6 @@
 import sys
 import uuid
 
-supported_types = (int, str, bytes, float,)
-
 ENCODING_DEFAULT = "utf-8"
 
 from base64 import decodebytes as base64_decode
@@ -22,33 +20,30 @@ def strxor(rhs, lhs):
 
     return bytes([x ^ y for x, y in zip(rhs, lhs)])
 
-def check_key(*args, **kwargs):
+def wrap_key(*args, first=True, select=False):
     """
-    Validate request key types and map.
+    Wrap request key in list, if needed.
 
     :param args: Method args.
     :type args: :obj:`tuple`
 
-    :param kwargs: Method kwargs.
-    :type kwargs: :obj:`dict`
+    :param first: ``True`` if this is the first recursion iteration.
+    :type first: :obj:`bool`
+
+    :param select: ``True`` if wrapping SELECT request key.
+    :type select: :obj:`bool`
 
     :rtype: :obj:`list`
     """
 
-    if 'first' not in kwargs:
-        kwargs['first'] = True
-    if 'select' not in kwargs:
-        kwargs['select'] = False
-    if len(args) == 0 and kwargs['select']:
+    if len(args) == 0 and select:
         return []
     if len(args) == 1:
-        if isinstance(args[0], (list, tuple)) and kwargs['first']:
-            kwargs['first'] = False
-            return check_key(*args[0], **kwargs)
-        elif args[0] is None and kwargs['select']:
+        if isinstance(args[0], (list, tuple)) and first:
+            return wrap_key(*args[0], first=False, select=select)
+        elif args[0] is None and select:
             return []
-    for key in args:
-        assert isinstance(key, supported_types)
+
     return list(args)
 
 

--- a/test/suites/test_datetime.py
+++ b/test/suites/test_datetime.py
@@ -32,6 +32,14 @@ class TestSuite_Datetime(unittest.TestCase):
                 parts = {1, 'string'},
                 unique = true})
 
+            pcall(function()
+                box.schema.space.create('test_pk')
+                box.space['test_pk']:create_index('primary', {
+                    type = 'tree',
+                    parts = {1, 'datetime'},
+                    unique = true})
+            end)
+
             box.schema.user.create('test', {password = 'test', if_not_exists = true})
             box.schema.user.grant('test', 'read,write,execute', 'universe')
 
@@ -527,6 +535,13 @@ class TestSuite_Datetime(unittest.TestCase):
         self.assertSequenceEqual(self.con.call('add', case['arg_1'], case['arg_2']),
                                  [case['res']])
 
+
+    @skip_or_run_datetime_test
+    def test_primary_key(self):
+        data = [tarantool.Datetime(year=1970, month=1, day=1), 'content']
+
+        self.assertSequenceEqual(self.con.insert('test_pk', data), [data])
+        self.assertSequenceEqual(self.con.select('test_pk', data[0]), [data])
 
     @classmethod
     def tearDownClass(self):

--- a/test/suites/test_decimal.py
+++ b/test/suites/test_decimal.py
@@ -31,6 +31,14 @@ class TestSuite_Decimal(unittest.TestCase):
                 parts = {1, 'string'},
                 unique = true})
 
+            pcall(function()
+                box.schema.space.create('test_pk')
+                box.space['test_pk']:create_index('primary', {
+                    type = 'tree',
+                    parts = {1, 'decimal'},
+                    unique = true})
+            end)
+
             box.schema.user.create('test', {password = 'test', if_not_exists = true})
             box.schema.user.grant('test', 'read,write,execute', 'universe')
         """)
@@ -419,6 +427,14 @@ class TestSuite_Decimal(unittest.TestCase):
                 """
 
                 self.assertSequenceEqual(self.con.eval(lua_eval), [True])
+
+
+    @skip_or_run_decimal_test
+    def test_primary_key(self):
+        data = [decimal.Decimal('0'), 'content']
+
+        self.assertSequenceEqual(self.con.insert('test_pk', data), [data])
+        self.assertSequenceEqual(self.con.select('test_pk', data[0]), [data])
 
 
     @classmethod

--- a/test/suites/test_uuid.py
+++ b/test/suites/test_uuid.py
@@ -31,6 +31,14 @@ class TestSuite_UUID(unittest.TestCase):
                 parts = {1, 'string'},
                 unique = true})
 
+            pcall(function()
+                box.schema.space.create('test_pk')
+                box.space['test_pk']:create_index('primary', {
+                    type = 'tree',
+                    parts = {1, 'uuid'},
+                    unique = true})
+            end)
+
             box.schema.user.create('test', {password = 'test', if_not_exists = true})
             box.schema.user.grant('test', 'read,write,execute', 'universe')
         """)
@@ -123,6 +131,14 @@ class TestSuite_UUID(unittest.TestCase):
                 """
 
                 self.assertSequenceEqual(self.con.eval(lua_eval), [True])
+
+
+    @skip_or_run_UUID_test
+    def test_primary_key(self):
+        data = [uuid.UUID('ae28d4f6-076c-49dd-8227-7f9fae9592d0'), 'content']
+
+        self.assertSequenceEqual(self.con.insert('test_pk', data), [data])
+        self.assertSequenceEqual(self.con.select('test_pk', data[0]), [data])
 
 
     @classmethod


### PR DESCRIPTION
Inserting a tuple with connector does not have any type restrictions on its contents: any MessagePack supported type is allowed. If there are any type violations on the Tarantool side, server would return the corresponding error. There is no reason to do any explicit type checks for request keys.

This patch fixed using extended types as keys. Tarantool 2.10 does not support indexing intervals, so there are no tests for INTERVAL extension type.

Closes #240