### PR TITLE
doc: fix readthedocs version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.10"
+  jobs:
+    post_checkout:
+      - git fetch --unshallow
+
+python:
+  install:
+    - method: pip
+      path: .
+    - requirements: docs/requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow any MessagePack supported type as a request key (#240).
 - Puting test files in pip package (#238).
 - Make connection close idempotent (#250).
+- readthedocs version (#255).
 
 ## 0.9.0 - 2022-06-20
 


### PR DESCRIPTION
Use unshallow clone [1] to negate the default readthedocs clone with depth 50.

1. https://github.com/readthedocs/readthedocs.org/issues/9708#issuecomment-1302235166

Closes #255