### PR TITLE
api: extend connect with `fetch_schema` param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ test/data/*.key
 !test/data/localhost.enc.key
 test/data/*.pem
 test/data/*.srl
+
+.rocks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Support `fetch_schema` parameter for a connection (#219).
 
 ### Added
 

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -359,7 +359,7 @@ Through the :class:`~tarantool.Connection` object, you can access
 
     >>> import tarantool
     >>> from tarantool.error import CrudModuleError, CrudModuleManyError, DatabaseError
-    >>> conn = tarantool.Connection(host='localhost',port=3301)
+    >>> conn = tarantool.Connection(host='localhost',port=3301,fetch_schema=False)
 
     >>> conn.crud_
     conn.crud_count(                conn.crud_insert(               conn.crud_insert_object_many(   

--- a/tarantool/connection_pool.py
+++ b/tarantool/connection_pool.py
@@ -378,7 +378,8 @@ class ConnectionPool(ConnectionInterface):
                  call_16=False,
                  connection_timeout=CONNECTION_TIMEOUT,
                  strategy_class=RoundRobinStrategy,
-                 refresh_delay=POOL_REFRESH_DELAY):
+                 refresh_delay=POOL_REFRESH_DELAY,
+                 fetch_schema=True):
         """
         :param addrs: List of dictionaries describing server addresses:
 
@@ -452,6 +453,9 @@ class ConnectionPool(ConnectionInterface):
             `box.info.ro`_ status background refreshes, in seconds.
         :type connection_timeout: :obj:`float`, optional
 
+        :param fetch_schema: Refer to
+            :paramref:`~tarantool.Connection.params.fetch_schema`.
+
         :raise: :exc:`~tarantool.error.ConfigurationError`,
             :class:`~tarantool.Connection` exceptions
 
@@ -500,7 +504,8 @@ class ConnectionPool(ConnectionInterface):
                     ssl_ciphers=addr['ssl_ciphers'],
                     ssl_password=addr['ssl_password'],
                     ssl_password_file=addr['ssl_password_file'],
-                    auth_type=addr['auth_type'])
+                    auth_type=addr['auth_type'],
+                    fetch_schema=fetch_schema)
             )
 
         if connect_now:

--- a/tarantool/mesh_connection.py
+++ b/tarantool/mesh_connection.py
@@ -283,7 +283,8 @@ class MeshConnection(Connection):
                  addrs=None,
                  strategy_class=RoundRobinStrategy,
                  cluster_discovery_function=None,
-                 cluster_discovery_delay=CLUSTER_DISCOVERY_DELAY):
+                 cluster_discovery_delay=CLUSTER_DISCOVERY_DELAY,
+                 fetch_schema=True):
         """
         :param host: Refer to
             :paramref:`~tarantool.Connection.params.host`.
@@ -425,6 +426,9 @@ class MeshConnection(Connection):
             list refresh.
         :type cluster_discovery_delay: :obj:`float`, optional
 
+        :param fetch_schema: Refer to
+            :paramref:`~tarantool.Connection.params.fetch_schema`.
+
         :raises: :exc:`~tarantool.error.ConfigurationError`,
             :class:`~tarantool.Connection` exceptions,
             :class:`~tarantool.MeshConnection.connect` exceptions
@@ -489,7 +493,8 @@ class MeshConnection(Connection):
             ssl_ciphers=addr['ssl_ciphers'],
             ssl_password=addr['ssl_password'],
             ssl_password_file=addr['ssl_password_file'],
-            auth_type=addr['auth_type'])
+            auth_type=addr['auth_type'],
+            fetch_schema=fetch_schema)
 
     def connect(self):
         """

--- a/tarantool/request.py
+++ b/tarantool/request.py
@@ -188,9 +188,13 @@ class Request(object):
         """
 
         self._sync = self.conn.generate_sync()
-        header = self._dumps({IPROTO_REQUEST_TYPE: self.request_type,
-                              IPROTO_SYNC: self._sync,
-                              IPROTO_SCHEMA_ID: self.conn.schema_version})
+        header_fields = {
+            IPROTO_REQUEST_TYPE: self.request_type,
+            IPROTO_SYNC: self._sync,
+        }
+        if self.conn.schema is not None:
+            header_fields[IPROTO_SCHEMA_ID] = self.conn.schema_version
+        header = self._dumps(header_fields)
 
         return self._dumps(length + len(header)) + header
 

--- a/test/suites/crud_server.lua
+++ b/test/suites/crud_server.lua
@@ -1,7 +1,58 @@
 #!/usr/bin/env tarantool
 
-local crud = require('crud')
-local vshard = require('vshard')
+local function configure_crud_instance(primary_listen, crud, vshard)
+    box.schema.create_space(
+    'tester', {
+    format = {
+        {name = 'id', type = 'unsigned'},
+        {name = 'bucket_id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+    }
+    })
+    box.space.tester:create_index('primary_index', {
+        parts = {
+            {field = 1, type = 'unsigned'},
+        },
+    })
+    box.space.tester:create_index('bucket_id', {
+        parts = {
+            {field = 2, type = 'unsigned'},
+        },
+        unique = false,
+    })
+
+    -- Setup vshard.
+    _G.vshard = vshard
+    box.once('guest', function()
+        box.schema.user.grant('guest', 'super')
+    end)
+    local uri = 'guest@0.0.0.0:' .. primary_listen
+    local cfg = {
+        bucket_count = 300,
+        sharding = {
+            [box.info().cluster.uuid] = {
+                replicas = {
+                    [box.info().uuid] = {
+                        uri = uri,
+                        name = 'storage',
+                        master = true,
+                    },
+                },
+            },
+        },
+    }
+    vshard.storage.cfg(cfg, box.info().uuid)
+    vshard.router.cfg(cfg)
+    vshard.router.bootstrap()
+
+    -- Initialize crud.
+    crud.init_storage()
+    crud.init_router()
+    crud.cfg{stats = true}
+end
+
+local crud_imported, crud = pcall(require, 'crud')
+local vshard_imported, vshard = pcall(require, 'vshard')
 
 local admin_listen = os.getenv("ADMIN")
 local primary_listen = os.getenv("LISTEN")
@@ -18,51 +69,17 @@ box.schema.user.grant(
     'read,write,execute',
     'universe'
 )
-box.schema.create_space(
- 'tester', {
-  format = {
-    {name = 'id', type = 'unsigned'},
-    {name = 'bucket_id', type = 'unsigned'},
-    {name = 'name', type = 'string'},
-  }
-})
-box.space.tester:create_index('primary_index', {
-    parts = {
-        {field = 1, type = 'unsigned'},
-    },
-})
-box.space.tester:create_index('bucket_id', {
-    parts = {
-        {field = 2, type = 'unsigned'},
-    },
-    unique = false,
-})
 
--- Setup vshard.
-_G.vshard = vshard
-box.once('guest', function()
-    box.schema.user.grant('guest', 'super')
-end)
-local uri = 'guest@0.0.0.0:' .. primary_listen
-local cfg = {
-    bucket_count = 300,
-    sharding = {
-        [box.info().cluster.uuid] = {
-            replicas = {
-                [box.info().uuid] = {
-                    uri = uri,
-                    name = 'storage',
-                    master = true,
-                },
-            },
-        },
-    },
-}
-vshard.storage.cfg(cfg, box.info().uuid)
-vshard.router.cfg(cfg)
-vshard.router.bootstrap()
-
--- Initialize crud.
-crud.init_storage()
-crud.init_router()
-crud.cfg{stats = true}
+if crud_imported == false or vshard_imported == false then
+    -- Set flag for unittest.
+    _G['ROCKS_IMPORT_FAIL'] = true
+    local fail_msg = 'The crud/vshard modules are not detected, ' ..
+                     'installation via rocks install is required ' ..
+                     'for CRUD testing purposes. You can use ' ..
+                     '<tarantoolctl rocks install crud> or ' ..
+                     '<tt rocks install crud> to install modules'
+    -- The print output will be captured in the logs.
+    print(fail_msg)
+else
+    configure_crud_instance(primary_listen, crud, vshard)
+end

--- a/test/suites/test_crud.py
+++ b/test/suites/test_crud.py
@@ -40,6 +40,12 @@ class TestSuite_Crud(unittest.TestCase):
                                                      user='guest', password='')
         # Time for vshard group configuration.
         time.sleep(1)
+        if self.conn.eval('return ROCKS_IMPORT_FAIL').data[0] == True:
+            raise unittest.SkipTest('The crud/vshard modules are not detected, ' +
+                                    'installation via rocks install is required ' +
+                                    'for CRUD testing purposes. You can use ' +
+                                    '<tarantoolctl rocks install crud> or ' +
+                                    '<tt rocks install crud> to install modules')
 
     crud_test_cases = {
         'crud_insert': {

--- a/test/suites/test_crud.py
+++ b/test/suites/test_crud.py
@@ -33,11 +33,12 @@ class TestSuite_Crud(unittest.TestCase):
         time.sleep(1)
         # Open connections to instance.
         self.conn = tarantool.Connection(host=self.host, port=self.port, 
-                                         user='guest', password='')
+                                         user='guest', password='', fetch_schema=False)
         self.conn_mesh = tarantool.MeshConnection(host=self.host, port=self.port, 
-                                         user='guest', password='')
+                                         user='guest', password='', fetch_schema=False)
         self.conn_pool = tarantool.ConnectionPool([{'host':self.host, 'port':self.port}], 
-                                                     user='guest', password='')
+                                                     user='guest', password='', 
+                                                     fetch_schema=False)
         # Time for vshard group configuration.
         time.sleep(1)
         if self.conn.eval('return ROCKS_IMPORT_FAIL').data[0] == True:


### PR DESCRIPTION
Added support of the `fetch_schema` parameter, which allows to ignore schema changes on the server.

By default, it is used `fetch_schema = True`:

```python
>>> import tarantool
>>> conn = tarantool.Connection(host='localhost', port=3303)

>>> conn.schema_version
80

>>> conn.schema.schema
{257: <tarantool.schema.SchemaSpace object at 0x10fd21a80>, '_vinyl_deferred_delete': <tarantool.schema.SchemaSpace object at 0x10fd21a80>, 272: <tarantool.schema.SchemaSpace object at 0x10fd229b0>, ... ... , 'tester': <tarantool.schema.SchemaSpace object at 0x10fd22830>}

>>> tester = conn.schema.schema['tester']
>>> tester
<tarantool.schema.SchemaSpace object at 0x10fd22830>
>>> tester.
tester.arity    tester.flush()  tester.format   tester.indexes  tester.name     tester.schema   tester.sid      
>>> tester.format
{'id': {'name': 'id', 'type': 'unsigned', 'id': 0}, 0: {'name': 'id', 'type': 'unsigned', 'id': 0}, 'name': {'name': 'name', 'type': 'string', 'id': 1}, 1: {'name': 'name', 'type': 'string', 'id': 1}}
```

If the `fetch_schema` is specified as `False`, fields `schema_version` and `schema` will no longer be present in the `connection` object:

```python
>>> import tarantool
>>> conn = tarantool.Connection(host='localhost', port=3303, fetch_schema=False)

>>> hasattr(conn, 'schema_version')
False
>>> hasattr(conn, 'schema')
False
```

In this case, requests to the server via the `connection.update_schema` will no longer be made when there is `SchemaReloadException`.

Closes #219