### PR TITLE
Fix packing in Github Actions

### DIFF
--- a/.github/workflows/packing.yml
+++ b/.github/workflows/packing.yml
@@ -2,10 +2,6 @@ name: packing
 
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
   pull_request:
   pull_request_target:
     types: [labeled]

--- a/.github/workflows/packing.yml
+++ b/.github/workflows/packing.yml
@@ -311,7 +311,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python and test running tools
-        run: dnf install -y python3 python3-libs python3-pip git make
+        # cmake rocks fail to install as expected without findutils
+        run: dnf install -y python3 python3-libs python3-pip git make cmake gcc unzip findutils
 
       - name: Remove connector source code
         run: python3 .github/scripts/remove_source_code.py
@@ -336,7 +337,7 @@ jobs:
       - name: Install the crud module for testing purposes
         run: |
           curl -L https://tarantool.io/release/2/installer.sh | bash
-          sudo apt install -y tt
+          sudo dnf install -y tt
           tt rocks install crud
 
       - name: Run tests
@@ -503,7 +504,7 @@ jobs:
       - name: Install the crud module for testing purposes
         run: |
           curl -L https://tarantool.io/release/2/installer.sh | bash
-          sudo apt install -y tt
+          apt install -y tt
           tt rocks install crud
 
       - name: Run tests

--- a/.github/workflows/packing.yml
+++ b/.github/workflows/packing.yml
@@ -16,7 +16,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
@@ -61,7 +61,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
@@ -116,7 +116,7 @@ jobs:
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     strategy:
       fail-fast: false
@@ -184,7 +184,7 @@ jobs:
       - run_tests_pip_package_linux
       - run_tests_pip_package_windows
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
@@ -222,7 +222,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     container:
       image: ${{ matrix.target.os }}:${{ matrix.target.dist }}
@@ -289,7 +289,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     container:
       image: ${{ matrix.target.os }}:${{ matrix.target.dist }}
@@ -311,7 +311,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python and test running tools
-        # cmake rocks fail to install as expected without findutils
+        # cmake rocks fail to install as expected without findutils:
+        # https://github.com/tarantool/luarocks/issues/14
         run: dnf install -y python3 python3-libs python3-pip git make cmake gcc unzip findutils
 
       - name: Remove connector source code
@@ -349,7 +350,7 @@ jobs:
     needs:
       - run_tests_rpm
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
@@ -399,7 +400,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
@@ -447,7 +448,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     container:
       image: ${{ matrix.target.os }}:${{ matrix.target.dist }}
@@ -516,7 +517,7 @@ jobs:
     needs:
       - run_tests_deb
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
### ci: use testing rules in packing

Use the same rules in packing as in testing to run on dev branches.

Follows #248

### ci: fix crud install

Set valid package manager for fedora. Fix using apt for docker:
debian/ubuntu containers are sudoless.

Follows #264

### ci: fixate OS versions

deb packages built with Ubuntu 22.04 fails to install on Debian 10, 11.