### PR TITLE
fix: IPROTO_ID auth method encoding

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -119,7 +119,7 @@ jobs:
             path: ''
           - bundle: 'bundle-2.10.0-1-gfa775b383-r486-linux-x86_64'
             path: ''
-          - bundle: 'sdk-gc64-2.11.0-entrypoint-107-ga18449d54-r524.linux.x86_64'
+          - bundle: 'sdk-gc64-2.11.0-entrypoint-113-g803baaffe-r529.linux.x86_64'
             path: 'dev/linux/x86_64/master/'
         python: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
@@ -169,7 +169,7 @@ jobs:
           make test
         env:
           TEST_TNT_SSL: ${{ matrix.tarantool.bundle == 'bundle-2.10.0-1-gfa775b383-r486-linux-x86_64' ||
-                            matrix.tarantool.bundle == 'sdk-gc64-2.11.0-entrypoint-107-ga18449d54-r524.linux.x86_64'}}
+                            matrix.tarantool.bundle == 'sdk-gc64-2.11.0-entrypoint-113-g803baaffe-r529.linux.x86_64'}}
 
   run_tests_pip_branch_install_linux:
     # We want to run on external PRs, but not on our own internal

--- a/tarantool/response.py
+++ b/tarantool/response.py
@@ -30,6 +30,7 @@ from tarantool.error import (
     SchemaReloadException,
     tnt_strerror
 )
+from tarantool.schema import to_unicode
 
 from tarantool.msgpack_ext.unpacker import ext_hook as unpacker_ext_hook
 
@@ -397,4 +398,4 @@ class ResponseProtocolVersion(Response):
 
         if self._return_code != 0:
             return None
-        return self._body.get(IPROTO_AUTH_TYPE)
+        return to_unicode(self._body.get(IPROTO_AUTH_TYPE))

--- a/test/suites/test_ssl.py
+++ b/test/suites/test_ssl.py
@@ -440,15 +440,12 @@ class TestSuite_Ssl(unittest.TestCase):
                 server_cert_file=self.cert_file,
                 server_auth_type=AUTH_TYPE_PAP_SHA256,
                 client_auth_type=AUTH_TYPE_CHAP_SHA1),
-            # uncomment after this Tarantool EE SDK will be available on CI:
-            # tarantool-enterprise-sdk-nogc64-2.11.0-entrypoint-110
-            #
-            # SslTestCase(
-            #     name="auth_type_use_server_id",
-            #     ok=True,
-            #     server_key_file=self.key_file,
-            #     server_cert_file=self.cert_file,
-            #     server_auth_type=AUTH_TYPE_PAP_SHA256),
+            SslTestCase(
+                name="auth_type_use_server_id",
+                ok=True,
+                server_key_file=self.key_file,
+                server_cert_file=self.cert_file,
+                server_auth_type=AUTH_TYPE_PAP_SHA256),
         ]
         for t in testcases:
             with self.subTest(msg=t.name):
@@ -559,15 +556,12 @@ class TestSuite_Ssl(unittest.TestCase):
                 client_cert_file=self.cert_file,
                 client_ca_file=self.ca_file,
                 client_auth_type=AUTH_TYPE_PAP_SHA256),
-            # uncomment after this Tarantool EE SDK will be available on CI:
-            # tarantool-enterprise-sdk-nogc64-2.11.0-entrypoint-110
-            #
-            # SslTestCase(
-            #     name="auth_type_use_server_id",
-            #     ok=True,
-            #     server_key_file=self.key_file,
-            #     server_cert_file=self.cert_file,
-            #     server_auth_type=AUTH_TYPE_PAP_SHA256),
+            SslTestCase(
+                name="auth_type_use_server_id",
+                ok=True,
+                server_key_file=self.key_file,
+                server_cert_file=self.cert_file,
+                server_auth_type=AUTH_TYPE_PAP_SHA256),
         ]
         for t in testcases:
             cnt = 5
@@ -683,19 +677,16 @@ class TestSuite_Ssl(unittest.TestCase):
                 client_cert_file=self.cert_file,
                 client_ca_file=self.ca_file,
                 client_auth_type=AUTH_TYPE_PAP_SHA256),
-            # uncomment after this Tarantool EE SDK will be available on CI:
-            # tarantool-enterprise-sdk-nogc64-2.11.0-entrypoint-110
-            #
-            # SslTestCase(
-            #     name="auth_type_use_server_id",
-            #     ok=True,
-            #     server_key_file=self.key_file,
-            #     server_cert_file=self.cert_file,
-            #     server_ca_file=self.ca_file,
-            #     server_auth_type=AUTH_TYPE_PAP_SHA256
-            #     client_key_file=self.key_file,
-            #     client_cert_file=self.cert_file,
-            #     client_ca_file=self.ca_file,),
+            SslTestCase(
+                name="auth_type_use_server_id",
+                ok=True,
+                server_key_file=self.key_file,
+                server_cert_file=self.cert_file,
+                server_ca_file=self.ca_file,
+                server_auth_type=AUTH_TYPE_PAP_SHA256,
+                client_key_file=self.key_file,
+                client_cert_file=self.cert_file,
+                client_ca_file=self.ca_file),
         ]
         for t in testcases:
             cnt = 5


### PR DESCRIPTION
If encoding=None is used (or similar decoder configuration), authentication method received in IPROTO_ID response is not an str, but a bytes object, which is unexpected. This patch fixed the behavior.

Follows #269