### PR TITLE
release: 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Support `fetch_schema` parameter for a connection (#219).
 
 ### Added
+- Support `fetch_schema` parameter for a connection (#219).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.12.0 - 2023-02-13
 
 ### Added
 - Support `fetch_schema` parameter for a connection (#219).
-
-### Changed
 
 ### Fixed
 - Error code on socket error (#279).

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,25 @@
+python3-tarantool (0.12.0-0) unstable; urgency=medium
+
+    ## Overview
+
+    This release introduces the support of `fetch_schema` connection
+    option to disable schema fetch and various fixes.
+
+    ### Breaking changes
+
+    This release should not break any existing behavior.
+
+    ### New features
+    - `fetch_schema` parameter for a connection (#219).
+
+    ### Bugfixes
+    - Error code on socket error (#279).
+
+    ### Thanks
+    We want to thank @bekhzod91 for a bugfix contribution.
+
+ -- Georgy Moiseev <georgy.moiseev@tarantool.org>  Mon, 13 Feb 2023 11:43:30 +0300
+
 python3-tarantool (0.11.0-0) unstable; urgency=medium
 
     ## Overview

--- a/debian/changelog
+++ b/debian/changelog
@@ -18,7 +18,7 @@ python3-tarantool (0.11.0-0) unstable; urgency=medium
     - Support specifying authentication method with `auth_type`
       and Tarantool EE `pap-sha256` authentication method (#269).
 
- -- Georgy.moiseev <admin@tarantool.org>  Sat, 31 Dec 2022 02:09:03 +0300
+ -- Georgy Moiseev <georgy.moiseev@tarantool.org>  Sat, 31 Dec 2022 02:09:03 +0300
 
 python3-tarantool (0.10.0-0) unstable; urgency=medium
 
@@ -223,7 +223,7 @@ python3-tarantool (0.10.0-0) unstable; urgency=medium
     - Pack and publish pip, RPM and deb packages with GitHub Actions (#164, #198).
     - Publish on readthedocs with CI/CD (including PRs) (#67).
 
- -- Georgy.moiseev <georgy.moiseev@tarantool.org>  Wed, 09 Nov 2022 13:14:20 +0300
+ -- Georgy Moiseev <georgy.moiseev@tarantool.org>  Wed, 09 Nov 2022 13:14:20 +0300
 
 tarantool-python (0.9.0-0) unstable; urgency=medium
     ## Overview


### PR DESCRIPTION
## Overview

This release introduces the support of `fetch_schema` connection option to disable schema fetch and various fixes.

### Breaking changes

This release should not break any existing behavior.

### New features
- `fetch_schema` parameter for a connection (#219).

### Bugfixes
- Error code on socket error (#279).

### Thanks
We want to thank @bekhzod91 for a bugfix contribution.