### PR TITLE
iproto: disable feature discovery for specific versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Discovery iproto features only for Tarantools since version 2.10.0 (#283). 
+
 ## 0.12.0 - 2023-02-13
 
 ### Added

--- a/tarantool/connection.py
+++ b/tarantool/connection.py
@@ -1014,7 +1014,8 @@ class Connection(ConnectionInterface):
         if greeting.protocol != "Binary":
             raise NetworkError("Unsupported protocol: " + greeting.protocol)
         self.version_id = greeting.version_id
-        self._check_features()
+        if self.version_id >= version_id(2, 10, 0):
+            self._check_features()
         self.uuid = greeting.uuid
         self._salt = greeting.salt
         if self.user:


### PR DESCRIPTION
"IProto features" are available since Tarantool 2.10 and there is no need to even try to fetch them for lower versions. Such check there is in netbox code [1].
Before this patch cartridge remote control closed the connection after RequestProtocolVersion however but for netbox it worked fine.
So let's uniform behaviour between connectors adding a small check to skip request if there is a gurarntee that "IProto features" are not supported.

Closes #283 

[1] https://github.com/tarantool/tarantool/pull/6434/commits/2cbec82d8451670967252862893795dcf6371adb#diff-a47383908beda20a06c9f64bf5c3d4c51879034e38bcdccdf45210e89ce6dfb7R1947