### PR TITLE
iproto: fix schema with constraints fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Discovery iproto features only for Tarantools since version 2.10.0 (#283). 
 
+### Fixed
+- Schema fetch for spaces with foreign keys (#282).
+
 ## 0.12.0 - 2023-02-13
 
 ### Added

--- a/tarantool/schema.py
+++ b/tarantool/schema.py
@@ -12,6 +12,13 @@ from tarantool.error import (
 import tarantool.const as const
 
 
+"""
+Max possible known schema depth is 4 if foreign keys are used (since
+Tarantool 2.10), but there are no restrictions in protocol.
+"""
+MAX_RECURSION_DEPTH = 32
+
+
 class RecursionError(Error):
     """
     Report the situation when max recursion depth is reached.
@@ -102,7 +109,7 @@ class SchemaIndex(object):
         self.unique = index_row[4]
         self.parts = []
         try:
-            parts_raw = to_unicode_recursive(index_row[5], 3)
+            parts_raw = to_unicode_recursive(index_row[5], MAX_RECURSION_DEPTH)
         except RecursionError as e:
             errmsg = 'Unexpected index parts structure: ' + str(e)
             raise SchemaError(errmsg)
@@ -159,7 +166,7 @@ class SchemaSpace(object):
             self.schema[self.name] = self
         self.format = dict()
         try:
-            format_raw = to_unicode_recursive(space_row[6], 3)
+            format_raw = to_unicode_recursive(space_row[6], MAX_RECURSION_DEPTH)
         except RecursionError as e:
             errmsg = 'Unexpected space format structure: ' + str(e)
             raise SchemaError(errmsg)

--- a/tarantool/schema.py
+++ b/tarantool/schema.py
@@ -97,7 +97,6 @@ class SchemaIndex(object):
         """
 
         self.iid = index_row[1]
-        self.name = index_row[2]
         self.name = to_unicode(index_row[2])
         self.index = index_row[3]
         self.unique = index_row[4]

--- a/test/suites/lib/skip.py
+++ b/test/suites/lib/skip.py
@@ -236,3 +236,14 @@ def skip_or_run_auth_type_test_call(self):
 
     return skip_or_run_test_tarantool_call(self, '2.11.0',
                                            'does not support auth type')
+
+def skip_or_run_constraints_test(func):
+    """Decorator to skip or run tests related to spaces with
+    schema constraints.
+
+    Tarantool supports schema constraints only since 2.10.0 version.
+    See https://github.com/tarantool/tarantool/issues/6436
+    """
+
+    return skip_or_run_test_tarantool(func, '2.10.0',
+                                      'does not support schema constraints')


### PR DESCRIPTION
Before this patch, only schemas with 3-level nesting were expected. Simple foreign keys schema has 4-level nesting. After this patch, nesting depth up to 32 is supported. (There are no known schemas with such nesting, but this should be enough for any future extensions.)

Closes #282