### PR TITLE
Get rid of pandas dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrate to built-in `Warning` instead of a custom one.
 - Migrate to built-in `RecursionError` instead of a custom one.
 - Collect full exception traceback.
+- Rework `tarantool.Datetime` implementation to use built-in
+  `datetime.datetime`. External changes are as follows. Some of them
+  are **breaking**.
+  - Package no longer depends on `pandas` (#290).
+  - `__repr__` has been changed.
+  - Input arguments are validated with `datetime.datetime` rules.
+  - Class is no longer expected to throw `pandas.Timestamp`
+    exceptions. `datetime.datetime` exceptions will
+    be thrown instead of them.
+  - Drop the support of `__eq__` operator for `pandas.Timestamp`.
 
 ## 0.12.1 - 2023-02-28
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -344,7 +344,6 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('http://docs.python.org/', None),
     'msgpack': ('https://msgpack-python.readthedocs.io/en/latest/', None),
-    'pandas': ('https://pandas.pydata.org/docs/', None),
     'pytz': ('https://pytz.sourceforge.net/', None),
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 msgpack
-pandas
 pytz
 dataclasses; python_version <= '3.6'

--- a/rpm/SPECS/python-tarantool.spec
+++ b/rpm/SPECS/python-tarantool.spec
@@ -29,7 +29,6 @@ Python client library for Tarantool.}
 %package -n python3-%{srcname}
 
 Requires:       python3-msgpack
-Requires:       python3-pandas
 Requires:       python3-pytz
 
 Summary:        %{summary}


### PR DESCRIPTION
Rework our implementation of tarantool.Datetime class. Previously it had relied on pandas.Timestamp and pandas.Timedelta. There were user complaints about pandas as a requirement since it's rather heavy. Now our implementation of datetime uses built-in datetime.datetime, datetime.timedelta and some other built-in tools.

It is expected that the implementation change wouldn't affect users, but some minor behavior traits were broken in this patch:
- Now we rely on datetime argument validation which differs from the pandas one. For example, it doesn't allow overflows for fields.  Exceptions that user may receive from internal datetime are, of course, had changed as well.
- We drop the support of `__eq__` for pandas.Timestamp. We simply compared underlying pandas.Timestamp with argument one, and now it's impossible. If the feature would be useful later, we may implement the comparison in some compatible way.
- `__repr__` has been changed since internal representation has been changed as well.

Closes #290