### PR TITLE
Remove join and subscribe & Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     exceptions. `datetime.datetime` exceptions will
     be thrown instead of them.
   - Drop the support of `__eq__` operator for `pandas.Timestamp`.
+- **Breaking**: Remove `join` and `subscribe` connection methods.
 
 ## 0.12.1 - 2023-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 1.0.0 - 2023-04-17
 
 ### Changed
 - **Breaking**: Allow only named `on_push` and `on_push_ctx` for `insert` and `replace`.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,35 @@
+python3-tarantool (1.0.0-0) unstable; urgency=medium
+
+    ## Overview
+
+    This release introduces several minor behavior changes
+    to make API more consistent.
+
+    Starting from this release, connector no longer depends on `pandas`.
+
+    ## Breaking changes
+
+    - Allow only named `on_push` and `on_push_ctx` for `insert` and `replace`.
+    - `tarantool.Datetime` `__repr__` has been changed.
+    - `tarantool.Datetime` input arguments are validated with `datetime.datetime` rules.
+    - `tarantool.Datetime` is no longer expected to throw `pandas.Timestamp`
+      exceptions. `datetime.datetime` exceptions will be thrown instead of them.
+    - Drop the support of `__eq__` operator of `tarantool.Datetime` for `pandas.Timestamp`.
+    - Remove `join` and `subscribe` connection methods.
+
+    ## Changes
+
+    - Migrate to built-in `Warning` instead of a custom one.
+    - Migrate to built-in `RecursionError` instead of a custom one.
+    - Collect full exception traceback.
+    - Package no longer depends on `pandas` (#290).
+
+    ## Infrastructure
+
+    - Lint the code with `pylint`, `flake8` and `codespell`.
+
+ -- Georgy.moiseev <georgy.moiseev@tarantool.org>  Mon, 17 Apr 2023 13:00:00 +0300
+
 python3-tarantool (0.12.1-0) unstable; urgency=medium
 
     ## Overview

--- a/tarantool/request.py
+++ b/tarantool/request.py
@@ -20,12 +20,8 @@ from tarantool.const import (
     IPROTO_TUPLE,
     IPROTO_FUNCTION_NAME,
     IPROTO_ITERATOR,
-    IPROTO_SERVER_UUID,
-    IPROTO_CLUSTER_UUID,
-    IPROTO_VCLOCK,
     IPROTO_EXPR,
     IPROTO_OPS,
-    # IPROTO_INDEX_BASE,
     IPROTO_SCHEMA_ID,
     IPROTO_SQL_TEXT,
     IPROTO_SQL_BIND,
@@ -44,8 +40,6 @@ from tarantool.const import (
     REQUEST_TYPE_EXECUTE,
     REQUEST_TYPE_EVAL,
     REQUEST_TYPE_AUTHENTICATE,
-    REQUEST_TYPE_JOIN,
-    REQUEST_TYPE_SUBSCRIBE,
     REQUEST_TYPE_ID,
     AUTH_TYPE_CHAP_SHA1,
     AUTH_TYPE_PAP_SHA256,
@@ -584,62 +578,6 @@ class RequestUpsert(Request):
                                     IPROTO_TUPLE: tuple_value,
                                     IPROTO_OPS: op_list})
 
-        self._body = request_body
-
-
-class RequestJoin(Request):
-    """
-    Represents JOIN request.
-    """
-
-    request_type = REQUEST_TYPE_JOIN
-
-    def __init__(self, conn, server_uuid):
-        """
-        :param conn: Request sender.
-        :type conn: :class:`~tarantool.Connection`
-
-        :param server_uuid: UUID of connector "server".
-        :type server_uuid: :obj:`str`
-        """
-
-        super().__init__(conn)
-        request_body = self._dumps({IPROTO_SERVER_UUID: server_uuid})
-        self._body = request_body
-
-
-class RequestSubscribe(Request):
-    """
-    Represents SUBSCRIBE request.
-    """
-
-    request_type = REQUEST_TYPE_SUBSCRIBE
-
-    def __init__(self, conn, cluster_uuid, server_uuid, vclock):
-        """
-        :param conn: Request sender.
-        :type conn: :class:`~tarantool.Connection`
-
-        :param server_uuid: UUID of connector "server".
-        :type server_uuid: :obj:`str`
-
-        :param server_uuid: UUID of connector "server".
-        :type server_uuid: :obj:`str`
-
-        :param vclock: Connector "server" vclock.
-        :type vclock: :obj:`dict`
-
-        :raise: :exc:`~AssertionError`
-        """
-
-        super().__init__(conn)
-        assert isinstance(vclock, dict)
-
-        request_body = self._dumps({
-            IPROTO_CLUSTER_UUID: cluster_uuid,
-            IPROTO_SERVER_UUID: server_uuid,
-            IPROTO_VCLOCK: vclock
-        })
         self._body = request_body
 
 


### PR DESCRIPTION
## api: remove join and subscribe

This is a breaking change.

Current join and subscribe implementations are rather useless. Connector does not provide any API to process incoming replication requests. The only supported scenario is to "connect as replica, skip everything that has been sent through replication, close on error".

Current Tarantool team product strategy is to develop CDC features, including replication support in language connectors, as Enterprise edition products [1]. Since we don't plan to provide proper join and subscribe implementation in the open-source connector in the future, we decide to drop current half-baked implementation to not confuse new users.

1. https://github.com/tarantool/go-tarantool/issues/203

## Release 1.0.0

### Overview

This release introduces several minor behavior changes
to make API more consistent.

Starting from this release, connector no longer depends on `pandas`.

### Breaking changes

- Allow only named `on_push` and `on_push_ctx` for `insert` and `replace`.
- `tarantool.Datetime` `__repr__` has been changed.
- `tarantool.Datetime` input arguments are validated with `datetime.datetime` rules.
- `tarantool.Datetime` is no longer expected to throw `pandas.Timestamp`
  exceptions. `datetime.datetime` exceptions will be thrown instead of them.
- Drop the support of `__eq__` operator of `tarantool.Datetime` for `pandas.Timestamp`.
- Remove `join` and `subscribe` connection methods.

### Changes

- Migrate to built-in `Warning` instead of a custom one.
- Migrate to built-in `RecursionError` instead of a custom one.
- Collect full exception traceback.
- Package no longer depends on `pandas` (#290).

### Infrastructure

- Lint the code with `pylint`, `flake8` and `codespell`.