### PR TITLE
test: fix compatibility with Tarantool master

### DIFF
--- a/.github/workflows/packing.yml
+++ b/.github/workflows/packing.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Install tarantool
         uses: tarantool/setup-tarantool@v2
         with:
-          tarantool-version: '2.10'
+          tarantool-version: '2.11'
 
       - name: Download pip package artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,6 +26,7 @@ jobs:
           - '1.10'
           - '2.8'
           - '2.10'
+          - '2.11'
         python:
           - '3.6'
           - '3.7'
@@ -119,8 +120,8 @@ jobs:
             path: ''
           - bundle: 'bundle-2.10.0-1-gfa775b383-r486-linux-x86_64'
             path: ''
-          - bundle: 'sdk-gc64-2.11.0-entrypoint-113-g803baaffe-r529.linux.x86_64'
-            path: 'dev/linux/x86_64/master/'
+          - bundle: 'sdk-gc64-2.11.0-rc2-0-r557.linux.x86_64'
+            path: 'release/linux/x86_64/2.11/'
         python: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
@@ -169,7 +170,7 @@ jobs:
           make test
         env:
           TEST_TNT_SSL: ${{ matrix.tarantool.bundle == 'bundle-2.10.0-1-gfa775b383-r486-linux-x86_64' ||
-                            matrix.tarantool.bundle == 'sdk-gc64-2.11.0-entrypoint-113-g803baaffe-r529.linux.x86_64'}}
+                            matrix.tarantool.bundle == 'sdk-gc64-2.11.0-rc2-0-r557.linux.x86_64'}}
 
   run_tests_pip_branch_install_linux:
     # We want to run on external PRs, but not on our own internal
@@ -187,7 +188,7 @@ jobs:
 
       matrix:
         tarantool:
-          - '2.10'
+          - '2.11'
         python:
           - '3.6'
           - '3.7'

--- a/test/suites/box.lua
+++ b/test/suites/box.lua
@@ -1,10 +1,16 @@
 #!/usr/bin/env tarantool
 
+local is_compat, compat = pcall(require, "compat")
 local os = require('os')
 
 local admin_listen = os.getenv("ADMIN")
 local primary_listen = os.getenv("LISTEN")
 local auth_type = os.getenv("AUTH_TYPE")
+
+local SQL_SEQ_SCAN_DEFAULT = os.getenv("SQL_SEQ_SCAN_DEFAULT")
+if is_compat and SQL_SEQ_SCAN_DEFAULT then
+    compat.sql_seq_scan_default = SQL_SEQ_SCAN_DEFAULT
+end
 
 require('console').listen(admin_listen)
 box.cfg{

--- a/test/suites/lib/tarantool_server.py
+++ b/test/suites/lib/tarantool_server.py
@@ -189,7 +189,8 @@ class TarantoolServer():
                 ssl_password=None,
                 ssl_password_file=None,
                 create_unix_socket=False,
-                auth_type=None):
+                auth_type=None,
+                sql_seq_scan_default=None):
         # pylint: disable=unused-argument
 
         if os.name == 'nt':
@@ -205,7 +206,8 @@ class TarantoolServer():
                  ssl_password=None,
                  ssl_password_file=None,
                  create_unix_socket=False,
-                 auth_type=None):
+                 auth_type=None,
+                 sql_seq_scan_default=None):
         # pylint: disable=consider-using-with
 
         os.popen('ulimit -c unlimited').close()
@@ -235,6 +237,7 @@ class TarantoolServer():
         self.ssl_password = ssl_password
         self.ssl_password_file = ssl_password_file
         self.auth_type = auth_type
+        self.sql_seq_scan_default = sql_seq_scan_default
         self._binary = None
         self._log_des = None
 
@@ -289,6 +292,8 @@ class TarantoolServer():
             os.putenv("AUTH_TYPE", self.auth_type)
         else:
             os.putenv("AUTH_TYPE", "")
+        if self.sql_seq_scan_default is not None:
+            os.putenv("SQL_SEQ_SCAN_DEFAULT", self.sql_seq_scan_default)
 
     def prepare_args(self):
         """

--- a/test/suites/test_dbapi.py
+++ b/test/suites/test_dbapi.py
@@ -27,7 +27,9 @@ class TestSuiteDBAPI(dbapi20.DatabaseAPI20Test):
     def setUpClass(cls):
         print(' DBAPI '.center(70, '='), file=sys.stderr)
         print('-' * 70, file=sys.stderr)
-        cls.srv = TarantoolServer()
+        # Select scans are not allowed with compat.sql_seq_scan_default = "new",
+        # but tests create cursors with fullscan.
+        cls.srv = TarantoolServer(sql_seq_scan_default="old")
         cls.srv.script = 'test/suites/box.lua'
         cls.srv.start()
         cls.con = tarantool.Connection(cls.srv.host, cls.srv.args['primary'])

--- a/test/suites/test_schema.py
+++ b/test/suites/test_schema.py
@@ -454,10 +454,21 @@ class TestSuiteSchemaAbstract(unittest.TestCase):
     def _run_test_schema_fetch_disable(self, con, mode=None):
         # Enable SQL test case for tarantool 2.* and higher.
         if int(str(self.srv.admin.tnt_version)[0]) > 1:
-            self.testing_methods['available']['execute'] = {
-                'input': ['SELECT * FROM "tester"'],
-                'output': [[1, None]],
-            }
+            if self.srv.admin.tnt_version >= pkg_resources.parse_version('2.11.0'):
+                # SEQSCAN keyword is explicitly allowing to use seqscan
+                # https://github.com/tarantool/tarantool/commit/77648827326ad268ec0ffbcd620c2371b65ef2b4
+                # It was introduced in 2.11.0-rc1. If compat.sql_seq_scan_default
+                # set to "new" (default value since 3.0), returns error
+                # if trying to scan without keyword.
+                self.testing_methods['available']['execute'] = {
+                    'input': ['SELECT * FROM SEQSCAN "tester"'],
+                    'output': [[1, None]],
+                }
+            else:
+                self.testing_methods['available']['execute'] = {
+                    'input': ['SELECT * FROM "tester"'],
+                    'output': [[1, None]],
+                }
 
         # Testing the schemaless connection with methods
         # that should NOT be available.


### PR DESCRIPTION
New Tarantool 3.0 patch introduces a breaking change [1]. This patch adds a compatibility layer to test instance.

It was decided to explicitly set SEQSCAN in our tests and change session options for DBAPI tests.

1. https://github.com/tarantool/tarantool/pull/8602