### PR TITLE
test: run cases for datetime with 2.11 fixes

### DIFF
--- a/.github/workflows/packing.yml
+++ b/.github/workflows/packing.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Python and basic packing tools
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install tools for packing and verification
         run: pip3 install wheel twine
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Remove connector source code
         run: python3 .github/scripts/remove_source_code.py
@@ -128,7 +128,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Remove connector source code
         run: python3 .github/scripts/remove_source_code.py
@@ -196,7 +196,7 @@ jobs:
       - name: Setup Python and basic packing tools
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install tools for package publishing
         run: pip3 install twine

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup python3 for tests
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.11'
 
       - name: Install connector requirements
         run: pip3 install -r requirements.txt

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,6 +33,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
         msgpack-deps:
           # latest msgpack will be installed as a part of requirements.txt
           - ''
@@ -42,17 +43,17 @@ jobs:
         # "This page is taking too long to load." error. Thus we use
         # pairwise testing.
         include:
-          - tarantool: '2.8'
-            python: '3.10'
+          - tarantool: '2.11'
+            python: '3.11'
             msgpack-deps: 'msgpack-python==0.4.0'
-          - tarantool: '2.8'
-            python: '3.10'
+          - tarantool: '2.11'
+            python: '3.11'
             msgpack-deps: 'msgpack==0.5.0'
-          - tarantool: '2.8'
-            python: '3.10'
+          - tarantool: '2.11'
+            python: '3.11'
             msgpack-deps: 'msgpack==0.6.2'
-          - tarantool: '2.8'
-            python: '3.10'
+          - tarantool: '2.11'
+            python: '3.11'
             msgpack-deps: 'msgpack==1.0.4'
 
     steps:
@@ -114,15 +115,15 @@ jobs:
       fail-fast: false
       matrix:
         tarantool:
-          - bundle: 'bundle-1.10.11-0-gf0b0e7ecf-r470'
-            path: ''
-          - bundle: 'bundle-2.8.3-21-g7d35cd2be-r470'
-            path: ''
-          - bundle: 'bundle-2.10.0-1-gfa775b383-r486-linux-x86_64'
-            path: ''
-          - bundle: 'sdk-gc64-2.11.0-rc2-0-r557.linux.x86_64'
+          - bundle: 'sdk-1.10.15-0-r563'
+            path: 'release/linux/x86_64/1.10/'
+          - bundle: 'sdk-2.8.4-0-r563'
+            path: 'release/linux/x86_64/2.8/'
+          - bundle: 'sdk-gc64-2.10.7-0-r563.linux.x86_64'
+            path: 'release/linux/x86_64/2.10/'
+          - bundle: 'sdk-gc64-2.11.0-0-r563.linux.x86_64'
             path: 'release/linux/x86_64/2.11/'
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python: ['3.6', '3.11']
 
     steps:
       - name: Clone the connector
@@ -169,8 +170,8 @@ jobs:
           source tarantool-enterprise/env.sh
           make test
         env:
-          TEST_TNT_SSL: ${{ matrix.tarantool.bundle == 'bundle-2.10.0-1-gfa775b383-r486-linux-x86_64' ||
-                            matrix.tarantool.bundle == 'sdk-gc64-2.11.0-rc2-0-r557.linux.x86_64'}}
+          TEST_TNT_SSL: ${{ matrix.tarantool.bundle == 'sdk-gc64-2.10.7-0-r563.linux.x86_64' ||
+                            matrix.tarantool.bundle == 'sdk-gc64-2.11.0-0-r563.linux.x86_64'}}
 
   run_tests_pip_branch_install_linux:
     # We want to run on external PRs, but not on our own internal
@@ -191,10 +192,7 @@ jobs:
           - '2.11'
         python:
           - '3.6'
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
+          - '3.11'
     steps:
       - name: Clone the connector repo
         uses: actions/checkout@v3
@@ -244,12 +242,10 @@ jobs:
       matrix:
         # Use reduced test matrix cause Windows pipelines are long.
         tarantool:
-          - '1.10'
-          - '2.8'
-          - '2.10.0.g0a5ce0b9c-1'
+          - '2.11.0.g247a9a418-1'
         python:
           - '3.6'
-          - '3.10'
+          - '3.11'
 
     steps:
       - name: Clone the connector
@@ -271,15 +267,7 @@ jobs:
         with:
           distribution: Ubuntu-20.04
 
-      - name: Install tarantool ${{ matrix.tarantool }} for WSL (2.8 and older)
-        if: (matrix.tarantool == '1.10') || (matrix.tarantool == '2.8')
-        shell: wsl-bash_Ubuntu-20.04 {0}
-        run: |
-          curl -L https://tarantool.io/installer.sh | VER=${{ matrix.tarantool }} bash -s -- --type "release"
-          sudo apt install -y tarantool tarantool-dev
-
       - name: Install tarantool ${{ matrix.tarantool }} for WSL (2.10 and newer)
-        if: (matrix.tarantool != '1.10') && (matrix.tarantool != '2.8')
         shell: wsl-bash_Ubuntu-20.04 {0}
         run: |
           curl -L https://tarantool.io/release/2/installer.sh | bash -s
@@ -324,10 +312,10 @@ jobs:
       matrix:
         # Use reduced test matrix cause Windows pipelines are long.
         tarantool:
-          - '2.10.0.g0a5ce0b9c-1'
+          - '2.11.0.g247a9a418-1'
         python:
           - '3.6'
-          - '3.10'
+          - '3.11'
     steps:
       - name: Clone the connector repo
         uses: actions/checkout@v3

--- a/tarantool/msgpack_ext/types/datetime.py
+++ b/tarantool/msgpack_ext/types/datetime.py
@@ -532,18 +532,6 @@ class Datetime():
             self_dt = self._datetime
             other_dt = other._datetime
 
-            # Tarantool datetime subtraction ignores timezone info, but it is a bug:
-            #
-            # Tarantool 2.10.1-0-g482d91c66
-            #
-            # tarantool> datetime.new{tz='MSK'} - datetime.new{tz='UTC'}
-            # ---
-            # - +0 seconds
-            # ...
-            #
-            # Refer to https://github.com/tarantool/tarantool/issues/7698
-            # for possible updates.
-
             if self_dt.tzinfo != other_dt.tzinfo:
                 other_dt = other_dt.astimezone(self_dt.tzinfo)
 

--- a/test/suites/lib/skip.py
+++ b/test/suites/lib/skip.py
@@ -205,6 +205,19 @@ def skip_or_run_datetime_test(func):
                                           'does not support datetime type')
 
 
+def skip_or_run_datetime_2_11_test(func):
+    """
+    Decorator to skip or run tests related to datetime module with
+    fixes introduced in 2.11 release.
+
+    See https://github.com/tarantool/tarantool/issues/7698 and
+    https://github.com/tarantool/tarantool/issues/7700
+    """
+
+    return skip_or_run_test_tarantool(func, '2.11.0',
+                                      'does not provide required datetime fixes')
+
+
 def skip_or_run_error_extra_info_test(func):
     """
     Decorator to skip or run tests related to extra error info


### PR DESCRIPTION
There were a couple of datetime bugs in core Tarantool [1, 2] in 2.10 that were fixed in 2.11. We had a couple of test cases which were skipped before because of these bugs. After 2.11 we may change these skips to conditional skips.

1. https://github.com/tarantool/tarantool/issues/7698
2. https://github.com/tarantool/tarantool/issues/7700

Closes #246