### PR TITLE
msgpack: support decimals with negative scale

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,9 +45,6 @@ jobs:
         include:
           - tarantool: '2.11'
             python: '3.11'
-            msgpack-deps: 'msgpack-python==0.4.0'
-          - tarantool: '2.11'
-            python: '3.11'
             msgpack-deps: 'msgpack==0.5.0'
           - tarantool: '2.11'
             python: '3.11'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Allow to require specific server protocol version and features (#267).
 
+### Changed
+- Drop `msgpack-python` support. Use `msgpack` instead.
+
 ### Fixed
 - Parsing of E-notation Tarantool decimals with positive exponent (PR #298).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Allow to require specific server protocol version and features (#267).
 
+### Fixed
+- Parsing of E-notation Tarantool decimals with positive exponent (PR #298).
+
 ## 1.0.0 - 2023-04-17
 
 ### Changed

--- a/test/suites/test_decimal.py
+++ b/test/suites/test_decimal.py
@@ -226,6 +226,39 @@ class TestSuiteDecimal(unittest.TestCase):
                         b'\x09\x87\x65\x43\x21\x98\x76\x54\x32\x1d'),
             'tarantool': "decimal.new('-1234567891234567890.0987654321987654321')",
         },
+        'decimal_exponent_1': {
+            'python': decimal.Decimal('1e33'),
+            'msgpack': (b'\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                        b'\x00\x00\x00\x00\x00\x00\x00\x0c'),
+            'tarantool': "decimal.new('1e33')",
+        },
+        'decimal_exponent_2': {
+            'python': decimal.Decimal('1.2345e33'),
+            'msgpack': (b'\x00\x01\x23\x45\x00\x00\x00\x00\x00\x00\x00'
+                        b'\x00\x00\x00\x00\x00\x00\x00\x0c'),
+            'tarantool': "decimal.new('1.2345e33')",
+        },
+        'decimal_exponent_3': {
+            'python': decimal.Decimal('1.2345e2'),
+            'msgpack': (b'\x02\x12\x34\x5c'),
+            'tarantool': "decimal.new('1.2345e2')",
+        },
+        'decimal_exponent_4': {
+            'python': decimal.Decimal('1.2345e4'),
+            'msgpack': (b'\x00\x12\x34\x5c'),
+            'tarantool': "decimal.new('1.2345e4')",
+        },
+        'decimal_exponent_5': {
+            'python': decimal.Decimal('-1e33'),
+            'msgpack': (b'\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                        b'\x00\x00\x00\x00\x00\x00\x00\x0d'),
+            'tarantool': "decimal.new('-1e33')",
+        },
+        'decimal_exponent_6': {
+            'python': decimal.Decimal('1e-33'),
+            'msgpack': (b'\x21\x1c'),
+            'tarantool': "decimal.new('1e-33')",
+        },
     }
 
     def test_msgpack_decode(self):


### PR DESCRIPTION
Current decimal external type parser do not expect negative scale in decimal payload. Negative scale is a positive exponent. It seems that the only way to obtain positive exponent is to use E-notation since Tarantool library do not truncate trailing zeroes before decimal point:

```lua
tarantool> msgpack.encode(decimal.new('1e33')):hex()
---
- c70301d0df1c
...

tarantool> msgpack.encode(decimal.new('1000000000000000000000000000000000')):hex()
---
- c713010001000000000000000000000000000000000c
...
```

There are two different bugs in current implementation:
- we support only `positive fixint` scale and do not expect `int 8` [2],
- we do not expect negative scale so positive exponent will be ignored.

This patch fixes both of them. See also [3].

1. https://github.com/tarantool/tarantool/blob/ba749e820bf0638aa3f79f266848590f9713c1cf/src/lib/core/decimal.c#L432-L450
2. https://github.com/msgpack/msgpack/blob/master/spec.md
3. https://github.com/tarantool/go-tarantool/pull/314