### PR TITLE
release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 1.1.0 - 2023-06-30
 
 ### Added
 - Allow to require specific server protocol version and features (#267).

--- a/debian/changelog
+++ b/debian/changelog
@@ -28,7 +28,7 @@ python3-tarantool (1.0.0-0) unstable; urgency=medium
 
     - Lint the code with `pylint`, `flake8` and `codespell`.
 
- -- Georgy.moiseev <georgy.moiseev@tarantool.org>  Mon, 17 Apr 2023 13:00:00 +0300
+ -- Georgy Moiseev <georgy.moiseev@tarantool.org>  Mon, 17 Apr 2023 13:00:00 +0300
 
 python3-tarantool (0.12.1-0) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,23 @@
+python3-tarantool (1.1.0-0) unstable; urgency=medium
+
+    ## Overview
+
+    This release introduces API to request server protocol version and
+    feature, as well as introduce decimal bugfix.
+
+    ## Breaking changes
+
+    - Drop `msgpack-python` support. (Package not supported since 2019.)
+      Use `msgpack` instead.
+
+    ## Added
+    - Allow to require specific server protocol version and features (#267).
+
+    ## Fixed
+    - Parsing of E-notation Tarantool decimals with positive exponent (PR #298).
+
+ -- Georgy Moiseev <georgy.moiseev@tarantool.org>  Fri, 30 Jun 2023 10:00:00 +0300
+
 python3-tarantool (1.0.0-0) unstable; urgency=medium
 
     ## Overview


### PR DESCRIPTION
## Overview

This release introduces API to request server protocol version and feature, as well as introduce decimal bugfix.

## Breaking changes

- Drop `msgpack-python` support. (Package not supported since 2019.) Use `msgpack` instead.

## Added
- Allow to require specific server protocol version and features (#267).

## Fixed
- Parsing of E-notation Tarantool decimals with positive exponent (PR #298).
