### PR TITLE
release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 1.1.1 - 2023-07-19
 
 ### Changed
-- Validate `tarantool.Interval` limits with the same rules as in Tarantool.
+- Validate `tarantool.Interval` limits with the same rules as in Tarantool (PR #302).
 
 ### Fixed
-- `tarantool.Interval` arithmetic with weeks
-- `tarantool.Interval` weeks display in `str()` and `repr()`
+- `tarantool.Interval` arithmetic with weeks (PR #302).
+- `tarantool.Interval` weeks display in `str()` and `repr()` (PR #302).
 
 ## 1.1.0 - 2023-06-30
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+python3-tarantool (1.1.1-0) unstable; urgency=medium
+
+    ## Overview
+
+    This release introduces various datetime interval fixes and quality of life
+    improvements.
+
+    ## Breaking changes
+    - Forbid to create datetime intervals out of Tarantool limits (PR #302).
+
+    ## Changed
+    - Validate `tarantool.Interval` limits with the same rules as in Tarantool (PR #302).
+
+    ## Fixed
+    - `tarantool.Interval` arithmetic with weeks (PR #302).
+    - `tarantool.Interval` weeks display in `str()` and `repr()` (PR #302).
+
+ -- Georgy Moiseev <georgy.moiseev@tarantool.org>  Wed, 19 Jul 2023 18:00:00 +0300
+
 python3-tarantool (1.1.0-0) unstable; urgency=medium
 
     ## Overview


### PR DESCRIPTION
## Overview

This release introduces various datetime interval fixes and quality of life improvements.

## Breaking changes
- Forbid to create datetime intervals out of Tarantool limits (PR #302).

## Changed
- Validate `tarantool.Interval` limits with the same rules as in Tarantool (PR #302).

## Fixed
- `tarantool.Interval` arithmetic with weeks (PR #302).
- `tarantool.Interval` weeks display in `str()` and `repr()` (PR #302).