### PR TITLE
release 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 1.1.2 - 2023-09-20
 
 ### Fixed
 - Exception rethrow in crud API (PR #310).

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+python3-tarantool (1.1.2-0) unstable; urgency=medium
+
+    ## Overview
+
+    This release introduce several bugfixes and behavior improvements.
+
+    ## Fixed
+
+    - Exception rethrow in crud API (PR #310).
+    - Work with timestamps larger than year 2038 for some platforms (like Windows) (PR #311).
+      It covers
+      - building new `tarantool.Datetime` objects from timestamp,
+      - parsing datetime objects received from Tarantool.
+
+ -- Georgy Moiseev <georgy.moiseev@tarantool.org>  Wed, 20 Sep 2023 10:00:00 +0300
+
 python3-tarantool (1.1.1-0) unstable; urgency=medium
 
     ## Overview


### PR DESCRIPTION
## Overview

This release introduce several bugfixes and behavior improvements.

## Fixed

- Exception rethrow in crud API (PR #310).
- Work with timestamps larger than year 2038 for some platforms (like Windows) (PR #311). It covers
  - building new `tarantool.Datetime` objects from timestamp,
  - parsing datetime objects received from Tarantool.