### PR TITLE
conn: create from socket fd

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,6 +27,7 @@ jobs:
           - '2.8'
           - '2.10'
           - '2.11'
+          - 'master'
         python:
           - '3.6'
           - '3.7'
@@ -57,10 +58,44 @@ jobs:
       - name: Clone the connector
         uses: actions/checkout@v3
 
+      - name: Setup tt
+        run: |
+          curl -L https://tarantool.io/release/2/installer.sh | sudo bash
+          sudo apt install -y tt
+          tt version
+          tt init 
+
       - name: Install tarantool ${{ matrix.tarantool }}
+        if: matrix.tarantool != 'master'
         uses: tarantool/setup-tarantool@v2
         with:
           tarantool-version: ${{ matrix.tarantool }}
+
+      - name: Get Tarantool master latest commit
+        if: matrix.tarantool == 'master'
+        run: |
+          commit_hash=$(git ls-remote https://github.com/tarantool/tarantool.git --branch master | head -c 8)
+          echo "LATEST_COMMIT=${commit_hash}" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Cache Tarantool master
+        if: matrix.tarantool == 'master'
+        id: cache-latest
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ github.workspace }}/bin
+            ${{ github.workspace }}/include
+          key: cache-latest-${{ env.LATEST_COMMIT }}
+
+      - name: Setup Tarantool master
+        if: matrix.tarantool == 'master' && steps.cache-latest.outputs.cache-hit != 'true'
+        run: |
+          tt install tarantool master
+
+      - name: Add Tarantool master to PATH
+        if: matrix.tarantool == 'master'
+        run: echo "${GITHUB_WORKSPACE}/bin" >> $GITHUB_PATH
 
       - name: Setup Python for tests
         uses: actions/setup-python@v4
@@ -86,8 +121,6 @@ jobs:
 
       - name: Install the crud module for testing purposes
         run: |
-          curl -L https://tarantool.io/release/2/installer.sh | bash
-          sudo apt install -y tt
           tt rocks install crud
 
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- The ability to connect to the Tarantool using an existing socket fd (#304).
+
 ## 1.1.2 - 2023-09-20
 
 ### Fixed

--- a/tarantool/__init__.py
+++ b/tarantool/__init__.py
@@ -51,7 +51,7 @@ except ImportError:
     __version__ = '0.0.0-dev'
 
 
-def connect(host="localhost", port=33013, user=None, password=None,
+def connect(host="localhost", port=33013, socket_fd=None, user=None, password=None,
             encoding=ENCODING_DEFAULT, transport=DEFAULT_TRANSPORT,
             ssl_key_file=DEFAULT_SSL_KEY_FILE,
             ssl_cert_file=DEFAULT_SSL_CERT_FILE,
@@ -63,6 +63,8 @@ def connect(host="localhost", port=33013, user=None, password=None,
     :param host: Refer to :paramref:`~tarantool.Connection.params.host`.
 
     :param port: Refer to :paramref:`~tarantool.Connection.params.port`.
+
+    :param socket_fd: Refer to :paramref:`~tarantool.Connection.params.socket_fd`.
 
     :param user: Refer to :paramref:`~tarantool.Connection.params.user`.
 
@@ -93,6 +95,7 @@ def connect(host="localhost", port=33013, user=None, password=None,
     """
 
     return Connection(host, port,
+                      socket_fd=socket_fd,
                       user=user,
                       password=password,
                       socket_timeout=SOCKET_TIMEOUT,

--- a/tarantool/const.py
+++ b/tarantool/const.py
@@ -103,6 +103,12 @@ IPROTO_FEATURE_PAGINATION = 4
 IPROTO_FEATURE_SPACE_AND_INDEX_NAMES = 5
 IPROTO_FEATURE_WATCH_ONCE = 6
 
+# Default value for host.
+DEFAULT_HOST = None
+# Default value for port.
+DEFAULT_PORT = None
+# Default value for socket_fd.
+DEFAULT_SOCKET_FD = None
 # Default value for connection timeout (seconds)
 CONNECTION_TIMEOUT = None
 # Default value for socket timeout (seconds)

--- a/tarantool/mesh_connection.py
+++ b/tarantool/mesh_connection.py
@@ -298,7 +298,7 @@ class MeshConnection(Connection):
             :paramref:`~tarantool.MeshConnection.params.addrs` list.
 
         :param port: Refer to
-            :paramref:`~tarantool.Connection.params.host`.
+            :paramref:`~tarantool.Connection.params.port`.
             Value would be used to add one more server in
             :paramref:`~tarantool.MeshConnection.params.addrs` list.
 

--- a/test/suites/__init__.py
+++ b/test/suites/__init__.py
@@ -15,6 +15,7 @@ from .test_pool import TestSuitePool
 from .test_execute import TestSuiteExecute
 from .test_dbapi import TestSuiteDBAPI
 from .test_encoding import TestSuiteEncoding
+from .test_socket_fd import TestSuiteSocketFD
 from .test_ssl import TestSuiteSsl
 from .test_decimal import TestSuiteDecimal
 from .test_uuid import TestSuiteUUID
@@ -33,7 +34,7 @@ test_cases = (TestSuiteSchemaUnicodeConnection,
               TestSuiteEncoding, TestSuitePool, TestSuiteSsl,
               TestSuiteDecimal, TestSuiteUUID, TestSuiteDatetime,
               TestSuiteInterval, TestSuitePackage, TestSuiteErrorExt,
-              TestSuitePush, TestSuiteConnection, TestSuiteCrud,)
+              TestSuitePush, TestSuiteConnection, TestSuiteCrud, TestSuiteSocketFD)
 
 
 def load_tests(loader, tests, pattern):

--- a/test/suites/lib/skip.py
+++ b/test/suites/lib/skip.py
@@ -306,3 +306,14 @@ def skip_or_run_iproto_basic_features_test(func):
 
     return skip_or_run_test_tarantool(func, '2.10.0',
                                       'does not support iproto ID and iproto basic features')
+
+
+def skip_or_run_box_session_new_tests(func):
+    """
+    Decorator to skip or run tests that use box.session.new.
+
+    Tarantool supports box.session.new only in current master since
+    commit 324872a.
+    See https://github.com/tarantool/tarantool/issues/8801.
+    """
+    return skip_or_run_test_tarantool(func, '3.0.0', 'does not support box.session.new')

--- a/test/suites/sidecar.py
+++ b/test/suites/sidecar.py
@@ -1,0 +1,16 @@
+# pylint: disable=missing-module-docstring
+import os
+
+import tarantool
+
+socket_fd = int(os.environ["SOCKET_FD"])
+
+conn = tarantool.connect(None, None, socket_fd=socket_fd)
+
+# Check user.
+assert conn.eval("return box.session.user()").data[0] == "test"
+
+# Check db operations.
+conn.insert("test", [1])
+conn.insert("test", [2])
+assert conn.select("test").data == [[1], [2]]

--- a/test/suites/test_mesh.py
+++ b/test/suites/test_mesh.py
@@ -135,7 +135,6 @@ class TestSuiteMesh(unittest.TestCase):
         # Verify that a bad address given at initialization leads
         # to an error.
         bad_addrs = [
-            {"port": 1234},                         # no host
             {"host": "localhost"},                  # no port
             {"host": "localhost", "port": "1234"},  # port is str
         ]

--- a/test/suites/test_socket_fd.py
+++ b/test/suites/test_socket_fd.py
@@ -1,0 +1,200 @@
+"""
+This module tests work with connection over socket fd.
+"""
+import os.path
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+import socket
+import sys
+import unittest
+
+import tarantool
+from .lib.skip import skip_or_run_box_session_new_tests
+from .lib.tarantool_server import TarantoolServer, find_port
+from .utils import assert_admin_success
+
+
+def find_python():
+    for _dir in os.environ["PATH"].split(os.pathsep):
+        exe = os.path.join(_dir, "python")
+        if os.access(exe, os.X_OK):
+            return os.path.abspath(exe)
+    raise RuntimeError("Can't find python executable in " + os.environ["PATH"])
+
+
+class TestSuiteSocketFD(unittest.TestCase):
+    EVAL_USER = "return box.session.user()"
+
+    @classmethod
+    def setUpClass(cls):
+        print(' SOCKET FD '.center(70, '='), file=sys.stderr)
+        print('-' * 70, file=sys.stderr)
+
+        cls.srv = TarantoolServer()
+        cls.srv.script = 'test/suites/box.lua'
+        cls.srv.start()
+        cls.tcp_port = find_port()
+
+        # Start tcp server to test work with blocking sockets.
+        # pylint: disable=consider-using-f-string
+        resp = cls.srv.admin("""
+            local socket = require('socket')
+
+            box.cfg{}
+            box.schema.user.create('test', {password = 'test', if_not_exists = true})
+            box.schema.user.grant('test', 'read,write,execute,create', 'universe',
+                                   nil, {if_not_exists = true})
+            box.schema.user.grant('guest', 'execute', 'universe',
+                                   nil, {if_not_exists = true})
+
+            socket.tcp_server('0.0.0.0', %d, function(s)
+                if not s:nonblock(true) then
+                    s:close()
+                    return
+                end
+                box.session.new({
+                    type = 'binary',
+                    fd = s:fd(),
+                    user = 'test',
+                })
+                s:detach()
+            end)
+
+            box.schema.create_space('test', {
+                format = {{type='unsigned', name='id'}},
+                if_not_exists = true,
+            })
+            box.space.test:create_index('primary')
+
+            return true
+        """ % cls.tcp_port)
+        assert_admin_success(resp)
+
+    @skip_or_run_box_session_new_tests
+    def setUp(self):
+        # Prevent a remote tarantool from clean our session.
+        if self.srv.is_started():
+            self.srv.touch_lock()
+
+    def _get_tt_sock(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect((self.srv.host, self.tcp_port))
+        return sock
+
+    def test_01_incorrect_params(self):
+        cases = {
+            "host and socket_fd": {
+                "args": {"host": "123", "socket_fd": 3},
+                "msg": "specifying both socket_fd and host/port is not allowed",
+            },
+            "port and socket_fd": {
+                "args": {"port": 14, "socket_fd": 3},
+                "msg": "specifying both socket_fd and host/port is not allowed",
+            },
+            "empty": {
+                "args": {},
+                "msg": r"host/port.* port.* or socket_fd",
+            },
+            "only host": {
+                "args": {"host": "localhost"},
+                "msg": "when specifying host, it is also necessary to specify port",
+            },
+        }
+
+        for name, case in cases.items():
+            with self.subTest(msg=name):
+                with self.assertRaisesRegex(tarantool.Error, case["msg"]):
+                    tarantool.Connection(**case["args"])
+
+    def test_02_socket_fd_connect(self):
+        sock = self._get_tt_sock()
+        conn = tarantool.connect(None, None, socket_fd=sock.fileno())
+        sock.detach()
+        try:
+            self.assertSequenceEqual(conn.eval(self.EVAL_USER), ["test"])
+        finally:
+            conn.close()
+
+    def test_03_socket_fd_re_auth(self):
+        sock = self._get_tt_sock()
+        conn = tarantool.connect(None, None, socket_fd=sock.fileno(), user="guest")
+        sock.detach()
+        try:
+            self.assertSequenceEqual(conn.eval(self.EVAL_USER), ["guest"])
+        finally:
+            conn.close()
+
+    @unittest.skipIf(sys.platform.startswith("win"),
+                     "Skip on Windows since it uses remote server")
+    def test_04_tarantool_made_socket(self):
+        python_exe = find_python()
+        cwd = os.getcwd()
+        side_script_path = os.path.join(cwd, "test", "suites", "sidecar.py")
+
+        # pylint: disable=consider-using-f-string
+        ret_code, err = self.srv.admin("""
+            local socket = require('socket')
+            local popen = require('popen')
+            local os = require('os')
+            local s1, s2 = socket.socketpair('AF_UNIX', 'SOCK_STREAM', 0)
+
+            --[[ Tell sidecar which fd use to connect. --]]
+            os.setenv('SOCKET_FD', tostring(s2:fd()))
+
+            --[[ Tell sidecar where find `tarantool` module. --]]
+            os.setenv('PYTHONPATH', (os.getenv('PYTHONPATH') or '') .. ':' .. '%s')
+
+            box.session.new({
+                type = 'binary',
+                fd = s1:fd(),
+                user = 'test',
+            })
+            s1:detach()
+
+            local ph, err = popen.new({'%s', '%s'}, {
+                stdout = popen.opts.PIPE,
+                stderr = popen.opts.PIPE,
+                inherit_fds = {s2:fd()},
+            })
+
+            if err ~= nil then
+                return 1, err
+            end
+
+            ph:wait()
+
+            local status_code = ph:info().status.exit_code
+            local stderr = ph:read({stderr=true}):rstrip()
+            return status_code, stderr
+        """ % (cwd, python_exe, side_script_path))
+        self.assertIsNone(err, err)
+        self.assertEqual(ret_code, 0)
+
+    def test_05_socket_fd_pool(self):
+        sock = self._get_tt_sock()
+        pool = tarantool.ConnectionPool(
+            addrs=[{'host': None, 'port': None, 'socket_fd': sock.fileno()}]
+        )
+        sock.detach()
+        try:
+            self.assertSequenceEqual(pool.eval(self.EVAL_USER, mode=tarantool.Mode.ANY), ["test"])
+        finally:
+            pool.close()
+
+    def test_06_socket_fd_mesh(self):
+        sock = self._get_tt_sock()
+        mesh = tarantool.MeshConnection(
+            host=None,
+            port=None,
+            socket_fd=sock.fileno()
+        )
+        sock.detach()
+        try:
+            self.assertSequenceEqual(mesh.eval(self.EVAL_USER), ["test"])
+        finally:
+            mesh.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.stop()
+        cls.srv.clean()


### PR DESCRIPTION
This patch adds the ability to create Tarantool connection using an existing socket fd.

I didn't forget about:
- [x] Tests
- [x] Changelog 

Closes #304