### PR TITLE
ci: bump actions in reusable_testing.yml

### DIFF
--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Clone the tarantool-python connector
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/tarantool-python
 
       - name: Download the tarantool build artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 
@@ -29,7 +29,7 @@ jobs:
         run: sudo dpkg -i tarantool*.deb
 
       - name: Setup python3 for tests
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
Bump version of the `actions/checkout` and `actions/download-artifact` actions to v4. Bump version of the `actions/setup-python` action to v5. It is needed for fixing the following GitHub warning:

    Node.js 16 actions are deprecated.
    Please update the following actions to use Node.js 20