### PR TITLE
test: use coverage instead of equality to test error payload

### DIFF
--- a/test/suites/test_dml.py
+++ b/test/suites/test_dml.py
@@ -419,13 +419,13 @@ class TestSuiteRequest(unittest.TestCase):
                 "Create access to function 'forbidden_function' is denied for user 'test'")
             self.assertEqual(exc.extra_info.errno, 0)
             self.assertEqual(exc.extra_info.errcode, 42)
-            self.assertEqual(
-                exc.extra_info.fields,
+            self.assertGreaterEqual(
+                exc.extra_info.fields.items(),
                 {
                     'object_type': 'function',
                     'object_name': 'forbidden_function',
                     'access_type': 'Create'
-                })
+                }.items())
             self.assertEqual(exc.extra_info.prev, None)
         else:
             self.fail('Expected error')

--- a/test/suites/test_error_ext.py
+++ b/test/suites/test_error_ext.py
@@ -327,7 +327,11 @@ class TestSuiteErrorExt(unittest.TestCase):
                     self.assertEqual(err.message, expected_err.message)
                     self.assertEqual(err.errno, expected_err.errno)
                     self.assertEqual(err.errcode, expected_err.errcode)
-                    self.assertEqual(err.fields, expected_err.fields)
+                    if expected_err.fields is not None:
+                        self.assertGreaterEqual(err.fields.items(),
+                                                expected_err.fields.items())
+                    else:
+                        self.assertEqual(err.fields, None)
 
                     err = err.prev
                     expected_err = expected_err.prev


### PR DESCRIPTION
We are going to add missing 'user' payload field for ACCESS_DENIED error which will break current tests. Let rewrite tests to allow adding new payload fields for this error.

Need for https://github.com/tarantool/tarantool/issues/9108