### PR TITLE
test: use coverage instead of equality to test error payload p.2

### DIFF
--- a/test/suites/test_dml.py
+++ b/test/suites/test_dml.py
@@ -391,7 +391,12 @@ class TestSuiteRequest(unittest.TestCase):
             self.assertEqual(exc.extra_info.message, "Timeout exceeded")
             self.assertEqual(exc.extra_info.errno, 0)
             self.assertEqual(exc.extra_info.errcode, 78)
-            self.assertEqual(exc.extra_info.fields, None)
+            actual_fields = exc.extra_info.fields
+            if actual_fields is None:
+                actual_fields = {}
+            expected_fields = {}
+            self.assertGreaterEqual(actual_fields.items(),
+                                    expected_fields.items())
             self.assertNotEqual(exc.extra_info.prev, None)
             prev = exc.extra_info.prev
             self.assertEqual(prev.type, 'ClientError')
@@ -400,7 +405,12 @@ class TestSuiteRequest(unittest.TestCase):
             self.assertEqual(prev.message, "Unknown error")
             self.assertEqual(prev.errno, 0)
             self.assertEqual(prev.errcode, 0)
-            self.assertEqual(prev.fields, None)
+            actual_fields = prev.fields
+            if actual_fields is None:
+                actual_fields = {}
+            expected_fields = {}
+            self.assertGreaterEqual(actual_fields.items(),
+                                    expected_fields.items())
         else:
             self.fail('Expected error')
 

--- a/test/suites/test_error_ext.py
+++ b/test/suites/test_error_ext.py
@@ -327,11 +327,14 @@ class TestSuiteErrorExt(unittest.TestCase):
                     self.assertEqual(err.message, expected_err.message)
                     self.assertEqual(err.errno, expected_err.errno)
                     self.assertEqual(err.errcode, expected_err.errcode)
-                    if expected_err.fields is not None:
-                        self.assertGreaterEqual(err.fields.items(),
-                                                expected_err.fields.items())
-                    else:
-                        self.assertEqual(err.fields, None)
+                    expected_fields = expected_err.fields
+                    if expected_fields is None:
+                        expected_fields = {}
+                    actual_fields = err.fields
+                    if actual_fields is None:
+                        actual_fields = {}
+                    self.assertGreaterEqual(actual_fields.items(),
+                                            expected_fields.items())
 
                     err = err.prev
                     expected_err = expected_err.prev


### PR DESCRIPTION
We are going to add 'name' payload field for every client error. So we need to tweak more test to handle this.

Need for https://github.com/tarantool/tarantool/issues/9875