### PR TITLE
codespell: ignore unittest naming

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = tarantool/msgpack_ext/types/timezones/timezones.py
-ignore-words-list = ans,gost,ro
+ignore-words-list = ans,gost,ro,assertIn


### PR DESCRIPTION
After resent update, codespell started to treat assertIn as a typo, and CI started to fail.