### PR TITLE
ci: bump ubuntu runner versions

### DIFF
--- a/.github/workflows/packing.yml
+++ b/.github/workflows/packing.yml
@@ -16,7 +16,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -61,7 +61,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -184,7 +184,7 @@ jobs:
       - run_tests_pip_package_linux
       - run_tests_pip_package_windows
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -222,7 +222,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     container:
       image: ${{ matrix.target.os }}:${{ matrix.target.dist }}
@@ -289,7 +289,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     container:
       image: ${{ matrix.target.os }}:${{ matrix.target.dist }}
@@ -350,7 +350,7 @@ jobs:
     needs:
       - run_tests_rpm
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -400,7 +400,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -448,7 +448,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     container:
       image: ${{ matrix.target.os }}:${{ matrix.target.dist }}
@@ -517,7 +517,7 @@ jobs:
     needs:
       - run_tests_deb
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/packing.yml
+++ b/.github/workflows/packing.yml
@@ -414,6 +414,7 @@ jobs:
 
       - name: Install deb packing tools
         run: |
+          sudo apt update
           sudo apt install -y devscripts equivs
 
       - name: Make changelog entry for non-release build

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -139,7 +139,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository &&
         github.event.label.name == 'full-ci')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -212,7 +212,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This patch does not update dependency for reusable_testing since this script is a part of DevX team responsibility and needs a separate check.