### PR TITLE
ci: fix deb build

### DIFF
--- a/.github/workflows/packing.yml
+++ b/.github/workflows/packing.yml
@@ -414,6 +414,7 @@ jobs:
 
       - name: Install deb packing tools
         run: |
+          sudo apt update
           sudo apt install -y devscripts equivs
 
       - name: Make changelog entry for non-release build


### PR DESCRIPTION
It seems that something has been changed in the package dependencies and `install` no longer works here without `update`.