### PR TITLE
ci: fix download artifact vulnerability

### DIFF
--- a/.github/workflows/packing.yml
+++ b/.github/workflows/packing.yml
@@ -43,7 +43,7 @@ jobs:
         run: make pip-dist-check
 
       - name: Archive pip artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: pip_dist
           path: pip_dist
@@ -84,7 +84,7 @@ jobs:
           tarantool-version: '2.11'
 
       - name: Download pip package artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.8
         with:
           name: pip_dist
           path: pip_dist
@@ -134,7 +134,7 @@ jobs:
         run: python3 .github/scripts/remove_source_code.py
 
       - name: Download pip package artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.8
         with:
           name: pip_dist
           path: pip_dist
@@ -202,7 +202,7 @@ jobs:
         run: pip3 install twine
 
       - name: Download pip package artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.8
         with:
           name: pip_dist
           path: pip_dist
@@ -271,7 +271,7 @@ jobs:
         run: make rpm-dist-check
 
       - name: Archive RPM artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: rpm_dist_${{ matrix.target.os }}_${{ matrix.target.dist }}
           path: rpm_dist
@@ -324,7 +324,7 @@ jobs:
           dnf install -y tarantool tarantool-devel
 
       - name: Download RPM artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.8
         with:
           name: rpm_dist_${{ matrix.target.os }}_${{ matrix.target.dist }}
           path: rpm_dist
@@ -372,7 +372,7 @@ jobs:
         run: sudo apt install -y curl make
 
       - name: Download RPM artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.8
         with:
           name: rpm_dist_${{ matrix.target.os }}_${{ matrix.target.dist }}
           path: rpm_dist
@@ -433,7 +433,7 @@ jobs:
         run: make deb-dist-check
 
       - name: Archive deb artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: deb_dist
           path: deb_dist
@@ -490,7 +490,7 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
 
       - name: Download deb artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.8
         with:
           name: deb_dist
           path: deb_dist
@@ -542,7 +542,7 @@ jobs:
         run: sudo apt install -y curl make
 
       - name: Download deb artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.8
         with:
           name: deb_dist
           path: deb_dist

--- a/.github/workflows/packing.yml
+++ b/.github/workflows/packing.yml
@@ -6,6 +6,10 @@ on:
   pull_request_target:
     types: [labeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pack_pip:
     # We want to run on external PRs, but not on our own internal

--- a/.github/workflows/packing.yml
+++ b/.github/workflows/packing.yml
@@ -324,7 +324,7 @@ jobs:
 
       - name: Install tarantool
         run: |
-          curl -L https://tarantool.io/yeohchA/release/2/installer.sh | bash
+          curl -L https://tarantool.io/release/2/installer.sh | bash
           dnf install -y tarantool tarantool-devel
 
       - name: Download RPM artifacts
@@ -488,7 +488,7 @@ jobs:
       - name: Install tarantool ${{ matrix.tarantool }}
         run: |
           apt install -y curl
-          curl -L https://tarantool.io/yeohchA/release/2/installer.sh | bash
+          curl -L https://tarantool.io/release/2/installer.sh | bash
           apt install -y tarantool tarantool-dev
         env:
           DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -19,7 +19,7 @@ jobs:
           repository: ${{ github.repository_owner }}/tarantool-python
 
       - name: Download the tarantool build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.8
         with:
           name: ${{ inputs.artifact_name }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,7 +33,6 @@ jobs:
           - '2.11'
           - 'master'
         python:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'
@@ -157,7 +156,7 @@ jobs:
             path: 'release/linux/x86_64/2.10/'
           - bundle: 'sdk-gc64-2.11.0-0-r563.linux.x86_64'
             path: 'release/linux/x86_64/2.11/'
-        python: ['3.6', '3.11']
+        python: ['3.7', '3.11']
 
     steps:
       - name: Clone the connector
@@ -225,7 +224,7 @@ jobs:
         tarantool:
           - '2.11'
         python:
-          - '3.6'
+          - '3.7'
           - '3.11'
     steps:
       - name: Clone the connector repo
@@ -278,7 +277,7 @@ jobs:
         tarantool:
           - '2.11.0.g247a9a418-1'
         python:
-          - '3.6'
+          - '3.7'
           - '3.11'
 
     steps:
@@ -348,7 +347,7 @@ jobs:
         tarantool:
           - '2.11.0.g247a9a418-1'
         python:
-          - '3.6'
+          - '3.7'
           - '3.11'
     steps:
       - name: Clone the connector repo

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,6 +6,10 @@ on:
   pull_request_target:
     types: [labeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run_tests_ce_linux:
     # We want to run on external PRs, but not on our own internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Drop Python 3.6 support (PR #327).
+
 ## 1.2.0 - 2024-03-27
 
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 msgpack
 pytz
-dataclasses; python_version <= '3.6'

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
     command_options=command_options,
     install_requires=get_dependencies('requirements.txt'),
     setup_requires=[
-        'setuptools_scm==6.4.2',
+        'setuptools_scm==7.1.0',
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ Package setup commands.
 import codecs
 import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py
 
 # Extra commands for documentation management


### PR DESCRIPTION
Versions of actions/download-artifact before 4.1.7 are vulnerable to arbitrary file write when downloading and extracting a specifically crafted artifact that contains path traversal filenames [1].

1. https://github.com/tarantool/tarantool-python/security/dependabot/4

Also see #326 

Since CI is failing now, several fixes were introduced, as well as Python 3.6 support drop.