### PR TITLE
ci: bump ubuntu version

### DIFF
--- a/.github/workflows/packing.yml
+++ b/.github/workflows/packing.yml
@@ -20,14 +20,14 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
 
     steps:
       - name: Clone the connector repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         # Checkout all tags for correct version computation.
         with:
           fetch-depth: 0
@@ -38,7 +38,9 @@ jobs:
           python-version: '3.11'
 
       - name: Install tools for packing and verification
-        run: pip3 install wheel twine
+        run: |
+          pip3 install wheel twine
+          pip3 install --upgrade setuptools
 
       - name: Pack source and binary files
         run: make pip-dist
@@ -65,14 +67,14 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
 
     steps:
       - name: Clone the connector repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -83,7 +85,7 @@ jobs:
         run: python3 .github/scripts/remove_source_code.py
 
       - name: Install tarantool
-        uses: tarantool/setup-tarantool@v2
+        uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: '2.11'
 
@@ -99,10 +101,13 @@ jobs:
       - name: Install test requirements
         run: pip3 install -r requirements-test.txt
 
+      # Installation of the specific CMake version is a hotfix for
+      # https://github.com/tarantool/checks/issues/64
       - name: Install the crud module for testing purposes
         run: |
           curl -L https://tarantool.io/release/2/installer.sh | bash
           sudo apt install -y tt
+          pip3 install cmake==3.15.3
           tt rocks install crud
 
       - name: Run tests
@@ -127,7 +132,7 @@ jobs:
 
     steps:
       - name: Clone the connector repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -188,14 +193,14 @@ jobs:
       - run_tests_pip_package_linux
       - run_tests_pip_package_windows
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
 
     steps:
       - name: Clone the connector repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python and basic packing tools
         uses: actions/setup-python@v4
@@ -226,7 +231,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     container:
       image: ${{ matrix.target.os }}:${{ matrix.target.dist }}
@@ -250,7 +255,7 @@ jobs:
         run: dnf install -y git
 
       - name: Clone the connector repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         # Checkout all tags for correct version computation.
         with:
           fetch-depth: 0
@@ -293,7 +298,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     container:
       image: ${{ matrix.target.os }}:${{ matrix.target.dist }}
@@ -312,7 +317,7 @@ jobs:
 
     steps:
       - name: Clone the connector repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python and test running tools
         # cmake rocks fail to install as expected without findutils:
@@ -343,6 +348,7 @@ jobs:
         run: |
           curl -L https://tarantool.io/release/2/installer.sh | bash
           sudo dnf install -y tt
+          pip3 install cmake==3.15.3
           tt rocks install crud
 
       - name: Run tests
@@ -354,7 +360,7 @@ jobs:
     needs:
       - run_tests_rpm
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
@@ -370,7 +376,7 @@ jobs:
 
     steps:
       - name: Clone the connector repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install tools for package publishing
         run: sudo apt install -y curl make
@@ -404,14 +410,14 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
 
     steps:
       - name: Clone the connector repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         # Checkout all tags for correct version computation
         with:
           fetch-depth: 0
@@ -420,6 +426,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y devscripts equivs
+          sudo apt install python3-setuptools python3-stdeb dh-python
 
       - name: Make changelog entry for non-release build
         if: startsWith(github.ref, 'refs/tags') != true
@@ -453,7 +460,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     container:
       image: ${{ matrix.target.os }}:${{ matrix.target.dist }}
@@ -463,18 +470,20 @@ jobs:
 
       matrix:
         target:
+        - os: debian
+          dist: bullseye # 11
+        - os: debian
+          dist: bookworm # 12
         - os: ubuntu
           dist: focal # 20.04
         - os: ubuntu
           dist: jammy # 22.04
-        - os: debian
-          dist: buster # 10
-        - os: debian
-          dist: bullseye # 11
+        - os: ubuntu
+          dist: noble # 24.04
 
     steps:
       - name: Clone the connector repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare apt
         run: apt update
@@ -504,17 +513,48 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
 
+      # Usage of venv is mandatory starting with Debian 12 and Ubuntu 24.04.
+      - name: Create venv
+        run: |
+          apt install -y python3-venv
+          python3 -m venv .venv
+
       - name: Install test requirements
         run: pip3 install -r requirements-test.txt
+        if: matrix.target.dist != 'bookworm' && matrix.target.dist != 'noble'
+
+      - name: Install test requirements
+        run: |
+          . .venv/bin/activate
+          pip3 install -r requirements-test.txt
+        if: matrix.target.dist == 'bookworm' || matrix.target.dist == 'noble'
 
       - name: Install the crud module for testing purposes
         run: |
           curl -L https://tarantool.io/release/2/installer.sh | bash
           apt install -y tt
           tt rocks install crud
+        if: matrix.target.dist != 'bookworm' && matrix.target.dist != 'noble'
+      
+      - name: Install the crud module for testing purposes
+        run: |
+          . .venv/bin/activate
+          curl -L https://tarantool.io/release/3/installer.sh | bash
+          apt install -y tt
+          tt rocks install crud
+        if: matrix.target.dist == 'bookworm' || matrix.target.dist == 'noble'
 
       - name: Run tests
         run: make test-pure-install
+        if: matrix.target.dist != 'bookworm' && matrix.target.dist != 'noble'
+
+      - name: Run tests
+        run: |
+          . .venv/bin/activate
+          export PYTHONPATH=$PYTHONPATH:/usr/lib/python3.11:/usr/lib/python3.12:/usr/bin:/usr/lib/python3/dist-packages
+          export PATH=$PATH:/usr/lib/python3/dist-packages
+          make test-pure-install
+        if: matrix.target.dist == 'bookworm' || matrix.target.dist == 'noble'
 
   publish_deb:
     if: startsWith(github.ref, 'refs/tags')
@@ -522,7 +562,7 @@ jobs:
     needs:
       - run_tests_deb
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
@@ -533,14 +573,18 @@ jobs:
           dist: focal # 20.04
         - os: ubuntu
           dist: jammy # 22.04
+        - os: ubuntu
+          dist: noble # 24.04
         - os: debian
           dist: buster # 10
         - os: debian
           dist: bullseye # 11
+        - os: debian
+          dist: bookworm # 12
 
     steps:
       - name: Clone the connector repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install tools for package publishing
         run: sudo apt install -y curl make

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone the tarantool-python connector
         uses: actions/checkout@v4
@@ -43,6 +43,7 @@ jobs:
         run: |
           curl -L https://tarantool.io/release/2/installer.sh | bash
           sudo apt install -y tt
+          pip3 install cmake==3.15.3
           tt rocks install crud
 
       - run: make test

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,20 +21,16 @@ jobs:
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
       matrix:
         tarantool:
-          - '1.10'
-          - '2.8'
-          - '2.10'
           - '2.11'
+          - '3.3'
           - 'master'
         python:
-          - '3.7'
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
@@ -47,30 +43,35 @@ jobs:
         # "This page is taking too long to load." error. Thus we use
         # pairwise testing.
         include:
-          - tarantool: '2.11'
+          - tarantool: '3.3'
             python: '3.11'
             msgpack-deps: 'msgpack==0.5.0'
-          - tarantool: '2.11'
+          - tarantool: '3.3'
             python: '3.11'
             msgpack-deps: 'msgpack==0.6.2'
-          - tarantool: '2.11'
+          - tarantool: '3.3'
             python: '3.11'
             msgpack-deps: 'msgpack==1.0.4'
 
     steps:
       - name: Clone the connector
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup tt
         run: |
-          curl -L https://tarantool.io/release/2/installer.sh | sudo bash
+          curl -L https://tarantool.io/release/3/installer.sh | sudo bash
           sudo apt install -y tt
           tt version
-          tt init 
+          tt init
+
+      # Installation of the specific CMake version is a hotfix for
+      # https://github.com/tarantool/checks/issues/64
+      - name: Install old CMake
+        run: pip3 install cmake==3.15.3
 
       - name: Install tarantool ${{ matrix.tarantool }}
         if: matrix.tarantool != 'master'
-        uses: tarantool/setup-tarantool@v2
+        uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: ${{ matrix.tarantool }}
 
@@ -123,8 +124,7 @@ jobs:
         run: pip3 install -r requirements-test.txt
 
       - name: Install the crud module for testing purposes
-        run: |
-          tt rocks install crud
+        run: tt rocks install crud
 
       - name: Run tests
         run: make test
@@ -142,34 +142,30 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository &&
         github.event.label.name == 'full-ci')
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
       matrix:
         tarantool:
-          - bundle: 'sdk-1.10.15-0-r563'
-            path: 'release/linux/x86_64/1.10/'
-          - bundle: 'sdk-2.8.4-0-r563'
-            path: 'release/linux/x86_64/2.8/'
-          - bundle: 'sdk-gc64-2.10.7-0-r563.linux.x86_64'
-            path: 'release/linux/x86_64/2.10/'
           - bundle: 'sdk-gc64-2.11.0-0-r563.linux.x86_64'
             path: 'release/linux/x86_64/2.11/'
-        python: ['3.7', '3.11']
+          - bundle: 'sdk-gc64-3.3.1-0-r55.linux.x86_64'
+            path: 'release/linux/x86_64/3.3/'
+        python: ['3.9', '3.11']
 
     steps:
       - name: Clone the connector
         # `ref` as merge request is needed for pull_request_target because this
         # target runs in the context of the base commit of the pull request.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: github.event_name == 'pull_request_target'
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Clone the connector
         if: github.event_name != 'pull_request_target'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Tarantool EE SDK
         run: |
@@ -194,8 +190,9 @@ jobs:
         # See more here: https://github.com/tarantool/tt/issues/282
         run: |
           source tarantool-enterprise/env.sh
-          curl -L https://tarantool.io/release/2/installer.sh | bash
+          curl -L https://tarantool.io/release/3/installer.sh | bash
           sudo apt install -y tt
+          pip3 install cmake==3.15.3
           tt rocks install crud TARANTOOL_DIR=$PWD/tarantool-enterprise
 
       - name: Run tests
@@ -215,7 +212,7 @@ jobs:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -223,15 +220,15 @@ jobs:
       matrix:
         tarantool:
           - '2.11'
+          - '3.3'
         python:
-          - '3.7'
           - '3.11'
     steps:
       - name: Clone the connector repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install tarantool ${{ matrix.tarantool }}
-        uses: tarantool/setup-tarantool@v2
+        uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: ${{ matrix.tarantool }}
 
@@ -246,13 +243,19 @@ jobs:
       - name: Install the package with pip
         run: pip3 install git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_REF
 
+      # Installation of the specific CMake version is a hotfix for
+      # https://github.com/tarantool/checks/issues/64
+      - name: Install old CMake
+        run: pip3 install cmake==3.15.3
+
       - name: Install test requirements
         run: pip3 install -r requirements-test.txt
 
       - name: Install the crud module for testing purposes
         run: |
-          curl -L https://tarantool.io/release/2/installer.sh | bash
+          curl -L https://tarantool.io/release/3/installer.sh | bash
           sudo apt install -y tt
+          pip3 install cmake==3.15.3
           tt rocks install crud
 
       - name: Run tests
@@ -275,14 +278,14 @@ jobs:
       matrix:
         # Use reduced test matrix cause Windows pipelines are long.
         tarantool:
+          # https://github.com/tarantool/tarantool-python/issues/331
           - '2.11.0.g247a9a418-1'
         python:
-          - '3.7'
           - '3.11'
 
     steps:
       - name: Clone the connector
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python for tests
         uses: actions/setup-python@v4
@@ -345,13 +348,13 @@ jobs:
       matrix:
         # Use reduced test matrix cause Windows pipelines are long.
         tarantool:
+          # https://github.com/tarantool/tarantool-python/issues/331
           - '2.11.0.g247a9a418-1'
         python:
-          - '3.7'
           - '3.11'
     steps:
       - name: Clone the connector repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python for tests
         uses: actions/setup-python@v4

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,3 +13,6 @@ python:
     - method: pip
       path: .
     - requirements: docs/requirements.txt
+
+sphinx:
+  configuration: docs/source/conf.py

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: python
 Priority: optional
 # See https://github.com/astraw/stdeb/issues/175 for dependencies
 Build-Depends: python3, python3-dev, python3-pip, python3-setuptools,
-  python3-distutils, python3-wheel, python3-stdeb, dh-python,
+  python3-wheel, python3-stdeb, dh-python,
   debhelper (>= 10)
 Standards-Version: 3.9.1
 Homepage: https://github.com/tarantool/tarantool-python

--- a/debian/rules
+++ b/debian/rules
@@ -18,3 +18,7 @@ override_dh_auto_install:
 
 override_dh_python2:
 	dh_python2 --no-guessing-versions
+
+# Force `xz` compression for older system with dpkg version < 1.15.6
+override_dh_builddeb:
+	dh_builddeb -- -Zxz

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 git+https://github.com/baztian/dbapi-compliance.git@ea7cb1b4#egg=dbapi-compliance
-pyyaml==6.0
+pyyaml >= 6.0.2
 importlib-metadata >= 1.0 ; python_version < '3.8'
 pylint == 3.3.0 ; python_version >= '3.9'
 pylint == 3.2.7 ; python_version == '3.8'
@@ -8,3 +8,4 @@ flake8 == 6.1.0 ; python_version >= '3.8'
 flake8 == 5.0.4 ; python_version < '3.8'
 codespell == 2.3.0 ; python_version >= '3.8'
 codespell == 2.2.5 ; python_version < '3.8'
+setuptools >= 75.3.2


### PR DESCRIPTION
Bump actions to use ubuntu-24.04 for fixing the following GitHub
warning:

    The Ubuntu 20.04 Actions runner image will begin deprecation
    on 2025-02-01.

Additionally this patch updates test requirements, list of OS
to test, forces `xz` compression type to support older OS versions,
hot-fixes `CMake` 3.5 problem on latest Ubuntu and Debian.

Part of #TNTP-1918