### PR TITLE
connection_pool: fix excessive idle CPU usage while waiting for requests

### DIFF
--- a/tarantool/connection_pool.py
+++ b/tarantool/connection_pool.py
@@ -660,8 +660,12 @@ class ConnectionPool(ConnectionInterface):
         """
 
         while unit.request_processing_enabled:
-            if not unit.input_queue.empty():
-                task = unit.input_queue.get()
+            try:
+                task = unit.input_queue.get(timeout=self.refresh_delay)
+            except queue.Empty:
+                task = None
+
+            if task:
                 method = getattr(Connection, task.method_name)
                 try:
                     resp = method(unit.conn, *task.args, **task.kwargs)


### PR DESCRIPTION
While using `ConnectionPool`, it was found that it uses 100% cpu for its threads when at rest. After examining its operation, it was realized that the `_request_process_loop` runs in an infinite loop, without blocking on waiting for the next request. To reduce the load, I suggest using already implemented wait for the next element in the queue's from package `queue` . 

To check the solution, I implemented a simple test that calculates the n-th element of the Fibonacci sequence using a `ConnectionPool` running in the background:

```python
import queue
import time

from tarantool import Connection
from tarantool.connection_pool import ConnectionPool as OriginalConnectionPool

def fib(n):
    a = 0
    b = 1
    for _ in range(n):
        a, b = b, a + b
    return a


class ConnectionPool(OriginalConnectionPool):
    # Override of the standard pool loop, which loaded the processor at 100% 
    # with an infinite constant loop
    def _request_process_loop( # noqa: max-complexity=8
        self, key, unit, last_refresh,
    ):
        """
        Request process background loop for a pool server. Started in
        a separate thread, one thread per server.

        :param key: Result of
            :meth:`~tarantool.connection_pool._make_key`.
        :type key: :obj:`str`

        :param unit: Server metainfo.
        :type unit: :class:`~tarantool.connection_pool.PoolUnit`

        :param last_refresh: Time of last metainfo refresh.
        :type last_refresh: :obj:`float`
        """

        while unit.request_processing_enabled:
            try:
                task = unit.input_queue.get(timeout=self.refresh_delay)
            except queue.Empty:
                task = None

            if task:
                method = getattr(Connection, task.method_name)
                try:
                    resp = method(unit.conn, *task.args, **task.kwargs)
                except Exception as exc:
                    unit.output_queue.put(exc)
                else:
                    unit.output_queue.put(resp)

            now = time.time()
            if now - last_refresh > self.refresh_delay:
                self._refresh_state(key)
                last_refresh = time.time()

def test_bench_updated_pool(benchmark):
    pool = ConnectionPool(
        addrs=[
            {
                'host': '127.0.0.1',
                'port': 3301,
            },
            {
                'host': '127.0.0.1',
                'port': 3302,
            },
            {
                'host': '127.0.0.1',
                'port': 3303,
            },
        ],
        user='guest',
    )

    benchmark(fib, 1000000)

    pool.close()

def test_bench_original_pool(benchmark):
    pool = OriginalConnectionPool(
        addrs=[
            {
                'host': '127.0.0.1',
                'port': 3301,
            },
            {
                'host': '127.0.0.1',
                'port': 3302,
            },
            {
                'host': '127.0.0.1',
                'port': 3303,
            },
        ],
        user='guest',
    )

    benchmark(fib, 1000000)

    pool.close()
```


I ran the test with the changes and the old ConnectionPool behavior. So i got the following test results:
<img width="1899" height="400" alt="image" src="https://github.com/user-attachments/assets/9859ffbb-d8ca-4785-938b-222a10ad9e50" />

I also looked at the distribution of processor activity using _py-spy_ for each of the tests:
- for current behavior:
<img width="1826" height="1149" alt="image" src="https://github.com/user-attachments/assets/3c70d596-66ad-4440-8548-8ca42596f2e8" />

- for new behavior:
<img width="1754" height="1223" alt="image" src="https://github.com/user-attachments/assets/521b36ac-4f21-4932-b998-219d6d4dac66" />


As you can see from the _py-spy_ snapshots, after the change, the processor is almost fully used for calculating Fibonacci sequence, while with the current behavior, most of the time is spent on `_request_process_loop`.